### PR TITLE
Allow DB connection retry.

### DIFF
--- a/src/api/database/sequelizeInstance.ts
+++ b/src/api/database/sequelizeInstance.ts
@@ -11,6 +11,12 @@ const sequelizeInstance = new Sequelize(apiEnv.DATABASE_URI, {
   // fix pg vercel bug
   // https://github.com/orgs/vercel/discussions/234
   dialectModule: require('pg'),
+  retry: {
+    match: [
+      /ConnectionError/
+    ],
+    max: 3
+}
 });
 
 hookIsPartialAfterSequelizeInit();


### PR DESCRIPTION
Task: https://www.notion.so/yuanjian/3524bb9cffe64164bd85f6e04b1e866c

Reference: https://sequelize.org/api/v6/identifiers.html#errors

Didn't find other retry-safe errors other than ConnectionError. Also maximum of 3 times is kinda default. 

Have tested on my local machine that it do retries when I kill DB process, but didn't find a way to do exponential backoff. 

