### PR TITLE
User caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fast-deep-equal": "^3.1.3",
     "framer-motion": "^6.5.1",
     "inquirer": "^8.0.0",
+    "lru-cache": "^10.0.0",
     "next": "^13.4.1-canary.2",
     "pg": "^8.9.0",
     "qs": "^6.11.1",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,36 +6,63 @@ import invariant from "tiny-invariant";
 import apiEnv from "./apiEnv";
 import { UniqueConstraintError } from "sequelize";
 import { AuthenticationClient } from 'authing-js-sdk'
+import { LRUCache } from 'lru-cache'
+
+const USER_CACHE_TTL_IN_MS = 60 * 60 * 1000
 
 const auth = (resource: Resource) => middleware(async ({ ctx, next }) => {
-  const authingUser = ctx.authToken ? await getAuthingUser(ctx.authToken) : null;  
-  if (!authingUser) {
-    throw new TRPCError({
-      code: 'UNAUTHORIZED',
-      message: 'Please login first',
-    });
-  }
-
-  // We only allow email-based accounts. If this line fails, check authing.cn configuration.
-  invariant(authingUser.email);
-  const user = await findOrCreateUser(authingUser.id, authingUser.email);
-
-  if (!isPermitted(user.roles, resource)) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Permission denied',
-    });
-  }
-  
-  return await next({
-    ctx: {
-      user,
-      authingUser: authingUser,
-    }
-  });
+  if (!ctx.authToken) throw unauthorized();
+  const user = await userCache.fetch(ctx.authToken);
+  invariant(user);
+  if (!isPermitted(user.roles, resource)) throw forbidden();
+  return await next({ ctx: { user: user }});
 });
 
 export default auth;
+
+/**
+ * In Serverless or Edge environment where multiple API instances may run, this function only clears the cache of the
+ * current process.
+ */
+export function invalidateLocalUserCache() {
+  userCache.clear();
+}
+
+const unauthorized = () => new TRPCError({
+  code: 'UNAUTHORIZED',
+  message: 'Please login first',
+});
+
+const forbidden = () => new TRPCError({
+  code: 'FORBIDDEN',
+  message: 'Access denied',
+});
+
+const userCache = new LRUCache<string, User>({
+  max: 1000,
+  ttl: USER_CACHE_TTL_IN_MS,
+  updateAgeOnGet: true,
+
+  fetchMethod: async(authToken: string) => {
+    const start = Date.now();
+    const authingUser = await getAuthingUser(authToken);
+    if (!authingUser) throw unauthorized();
+
+    const startUser = Date.now();
+    // We only allow email-based accounts. If this line fails, check authing.cn configuration.
+    invariant(authingUser.email);
+    const user = await findOrCreateUser(authingUser.id, authingUser.email);
+    const end = Date.now();
+
+    console.log(`
+      > User cache miss for '${user.email}'. Time spent in ms:
+      >
+      > getAuthingUser():   ${startUser - start}
+      > findOrCreateUser(): ${end - startUser}
+    `);
+    return user;
+  }
+});
 
 async function getAuthingUser(authToken: string) {
   const authing = new AuthenticationClient({
@@ -48,12 +75,10 @@ async function getAuthingUser(authToken: string) {
 
 async function findOrCreateUser(clientId: string, email: string): Promise<User> {  
   /**
-   * Frontend calls user.profile multiple times when a new user logs in, causing parallel User.create() from time to
+   * Multiple APIs may be called at the same time, causing parallel User.create() calls from time to
    * time which results in unique constraint errors.
    * 
    * As a speed optimization, we simply retry on such errors instead of using pessimistic locking.
-   * 
-   * TODO: Fix the frontend to suppress unnecessary calls to user.profile.
    */
   while (true) {
     const user = await User.findOne({ where: { clientId: clientId } });

--- a/src/api/routes/user.ts
+++ b/src/api/routes/user.ts
@@ -1,6 +1,6 @@
 import { procedure, router } from "../tServer";
 import { z } from "zod";
-import auth from "../auth";
+import auth, { invalidateLocalUserCache } from "../auth";
 import { IUser } from "../../shared/user";
 import pinyin from 'tiny-pinyin';
 
@@ -13,6 +13,10 @@ const user = router({
     return ctx.user as IUser;
   }),
 
+  /**
+   * In Edge or Serverless environments, user profile updates may take up to auth.USER_CACHE_TTL_IN_MS to propagate.
+   * TODO: add a warning message in profile change UI.
+   */
   updateProfile: procedure.use(
     auth('profile:write')
   ).input(
@@ -23,6 +27,7 @@ const user = router({
       name: input.name,
       pinyin: pinyin.convertToPinyin(input.name),
     });
+    invalidateLocalUserCache();
   })
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4681,6 +4681,11 @@ loupe@^2.3.1:
   dependencies:
     get-func-name "^2.0.0"
 
+lru-cache@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.0.tgz#b9e2a6a72a129d81ab317202d93c7691df727e61"
+  integrity sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"


### PR DESCRIPTION
Significantly improve loading time by avoiding repeated calls to authing.cn and db query:

      > User cache miss for 'fooo@bar'. Time spent in ms:
      >
      > getAuthingUser():   1149
      > findOrCreateUser(): 931