### PR TITLE
Remove dropping db option from `yarn sync-database`

### DIFF
--- a/tools/syncDatabase.ts
+++ b/tools/syncDatabase.ts
@@ -1,31 +1,7 @@
-import inquirer from 'inquirer';
 import sequelizeInstance from "../src/api/database/sequelizeInstance";
 
-inquirer
-  .prompt([
-    {
-      type: 'list',
-      name: 'action',
-      prefix: 'Affected tables: \n' + Object.values(sequelizeInstance.modelManager.all).map(m => '\t' + m.tableName).join('\n') + '\n',
-      message: 'Choose your action',
-      choices: [
-        'Alter tables without dropping anything',
-        'Delete tables (if any) and recreate them'
-      ]
-    },
-  ])
-  .then((answers: {action: string}) => {
-    console.log(`Your action is ${answers.action}.`);
+console.log();
+console.log("Syncing database... It may take a while. Grab a coffee.");
+console.log();
 
-    if (answers.action.startsWith('Delete')) {
-      console.log('### NO-OP. Modify source code if you really intend to drop all data.');
-      // sequelizeInstance.sync({ force: true });
-    } else if (answers.action.startsWith('Alter')) {
-      sequelizeInstance.sync({ alter: { drop: false } });
-    }
-  })
-  .catch((error) => {
-    console.log(`Error: ${error}`);
-  });
-
-
+sequelizeInstance.sync({ alter: { drop: false } }).then();


### PR DESCRIPTION
If users really want to start over, the cleanest way is to drop db and recreate a new one.