### PR TITLE
Resolve import errors and update eslint import restriction rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,19 +8,19 @@
         "target": "./src/api",
         "from": ["./src"],
         "except":["./api", "./shared"],
-        "message": "src/api cannot refer the files outside /shared or /api, see README"
+        "message": "src/api cannot refer the files outside /shared or /api, see README.md"
       },
       {
         "target": "./src/shared",
         "from": ["./src"],
         "except":["./shared"],
-        "message": "src/shared cannot refer the files outside /shared, see README"
+        "message": "src/shared cannot refer the files outside /shared, see README.md"
       },
       {
         "target": ["./src/!(api|pages)/**/*","./src/pages/!(api)/**/*","./src/*.[t]*","./src/pages/*.[t]*"],
         "from": ["./src/api/"],
         "except": ["./apiRouter.ts"],
-        "message": "files outside src/api cannot refer files in /api, see README"
+        "message": "files outside src/api cannot refer files in /api, see README.md"
       }]
     }
   ]}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,8 +17,9 @@
         "message": "src/shared cannot refer the files outside /shared, see README"
       },
       {
-        "target": ["./src/!(api)/**/*","./src/*.tsx"],
-        "from": ["./src/api/**/*"],
+        "target": ["./src/!(api|pages)/**/*","./src/pages/!(api)/**/*","./src/*.[t]*","./src/pages/*.[t]*"],
+        "from": ["./src/api/"],
+        "except": ["./apiRouter.ts"],
         "message": "files outside src/api cannot refer files in /api, see README"
       }]
     }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We follow [next.js convention](https://nextjs.org/docs/getting-started/project-s
 
 * files in `src/shared` must not refer to files outside of `src/shared`,
 * files in `src/api` must not refer to files outside of `src/api` or `src/shared`, and
-* files outside of `src/api` must not refer to files in `src/api`.
+* files outside of `src/api` must not refer to files in `src/api`, except in the case of `src/trpc.ts` refers to `src/api/apiRouter.ts`
 
 That is, only the dependencies demonstrated below are allowed:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We follow [next.js convention](https://nextjs.org/docs/getting-started/project-s
 
 * files in `src/shared` must not refer to files outside of `src/shared`,
 * files in `src/api` must not refer to files outside of `src/api` or `src/shared`, and
-* files outside of `src/api` must not refer to files in `src/api`, except in the case of `src/trpc.ts` refers to `src/api/apiRouter.ts`
+* files outside of `src/api` must not refer to files in `src/api`
 
 That is, only the dependencies demonstrated below are allowed:
 

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -7,20 +7,7 @@ import Group from "../database/models/Group";
 import User from "../database/models/User";
 import { TRPCError } from "@trpc/server";
 import { isPermitted } from "../../shared/Role";
-import { zGroup } from "shared/Group";
-
-const zTranscript = z.object({
-  transcriptId: z.string(),
-  startedAt: z.date(),
-  endedAt: z.date(),
-  group: zGroup,
-  summaries: z.array(z.object({
-      summaryKey: z.string(),
-      summary: z.string(),
-  })),
-});
-
-export type Transcript = z.TypeOf<typeof zTranscript>;
+import { zTranscript } from "shared/Transcript";
 
 const get = procedure
     // We will throw access denied later if the user isn't a privileged user and isn't in the group.

--- a/src/pages/groups/[groupId]/transcripts/[transcriptId].tsx
+++ b/src/pages/groups/[groupId]/transcripts/[transcriptId].tsx
@@ -13,7 +13,7 @@ import { NextPageWithLayout } from "../../../../NextPageWithLayout";
 import AppLayout from "../../../../AppLayout";
 import { trpcNext } from "../../../../trpc";
 import GroupBar from 'components/GroupBar';
-import { Transcript } from 'api/routes/transcripts';
+import { Transcript } from '../../../../shared/Transcript';
 import PageBreadcrumb from 'components/PageBreadcrumb';
 import { useRouter } from 'next/router';
 import invariant from 'tiny-invariant';

--- a/src/shared/Transcript.ts
+++ b/src/shared/Transcript.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { zGroup } from "shared/Group";
+
+export const zTranscript = z.object({
+    transcriptId: z.string(),
+    startedAt: z.date(),
+    endedAt: z.date(),
+    group: zGroup,
+    summaries: z.array(z.object({
+        summaryKey: z.string(),
+        summary: z.string(),
+    })),
+  });
+
+export type Transcript = z.TypeOf<typeof zTranscript>;


### PR DESCRIPTION
- Updated import restriction rules in `eslintrc.json` on `src/pages/api` and `*.ts` and `*.tsx` files
- Resolved import errors in `src/pages/groups` by moving customized zod schema and type from `src/api/routes/transcript.ts` to `src/shared/Transcript.ts`
- Added exception on `src/trpc.ts`'s reference to `src/api/apiRouter.ts`, this should be the only case allowing file outside `src/api` importing files under `src/api`