### PR TITLE
add no-absolute-path rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
         "except": ["./apiRouter.ts"],
         "message": "Files outside of `src/api` must not refer to files in `src/api`. See README.md"
       }]
-    }
-  ]}
+    }],
+    "import/no-absolute-path":"error"
+  }
 }


### PR DESCRIPTION
added Eslint rule `import/no-absolute-path` to forbid using absolute import paths