### PR TITLE
add import rule and fix to use relative paths

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": "next/core-web-vitals",
+  "plugins": ["import"],
   "rules": {
     "object-curly-spacing": ["warn", "always"],
     "import/no-restricted-paths": ["error",
@@ -23,6 +24,31 @@
         "message": "Files outside of `src/api` must not refer to files in `src/api`. See README.md"
       }]
     }],
-    "import/no-absolute-path":"error"
+    "import/no-absolute-path":"error",
+    "no-restricted-imports": [
+      "error",{
+        "paths":[
+          // files under src
+        "AppLayout",
+        "AutosaveContext",
+        "guard",
+        "NextPageWithLayout",
+        "parseQueryParamter",
+        "requestFinishLink",
+        "trpc",
+        "UseContext"],
+        "patterns": [
+          {
+            "group": [
+              "api/*",
+              "components/*",
+              "pages/*",
+              "shared/*",
+              "theme/*"
+            ],
+            "message": "Please use relatvie path"
+          }
+        ]
+    }]
   }
 }

--- a/src/AppLayout.tsx
+++ b/src/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@chakra-ui/react'
-import Footer, { footerBreakpoint, footerMarginTop } from 'components/Footer'
+import Footer, { footerBreakpoint, footerMarginTop } from './components/Footer'
 import { FC, PropsWithChildren, ReactNode, useEffect, useRef, useState } from 'react'
 
 // Code example: https://github.com/Authing/Guard/tree/dev-v6/examples/guard-nextjs-react18
@@ -10,7 +10,7 @@ import trpc from "./trpc";
 import { BeatLoader } from 'react-spinners';
 import guard from './guard';
 import User from './shared/User'
-import NavBars, { sidebarBreakpoint, sidebarContentMarginTop, topbarHeight } from 'components/Navbars'
+import NavBars, { sidebarBreakpoint, sidebarContentMarginTop, topbarHeight } from './components/Navbars'
 
 interface AppLayoutProps extends PropsWithChildren {
   unlimitedPageWidth?: boolean,

--- a/src/api/routes/assessments.ts
+++ b/src/api/routes/assessments.ts
@@ -7,7 +7,7 @@ import { zAssessment } from "../../shared/Assessment";
 import Partnership from "../database/models/Partnership";
 import { TRPCError } from "@trpc/server";
 import { noPermissionError, notFoundError } from "../errors";
-import { includeForPartnership } from "api/database/models/attributesAndIncludes";
+import { includeForPartnership } from "../../api/database/models/attributesAndIncludes";
 
 /**
  * @returns the ID of the created assessment.

--- a/src/api/routes/meetings.ts
+++ b/src/api/routes/meetings.ts
@@ -5,12 +5,12 @@ import { authUser } from "../auth";
 import db from "../database/db";
 import DbGroup from "../database/models/Group";
 import { createMeeting, getMeeting } from "../TencentMeeting";
-import { formatGroupName } from "shared/strings";
-import apiEnv from "api/apiEnv";
+import { formatGroupName } from "../../shared/strings";
+import apiEnv from "../../api/apiEnv";
 import sleep from "../../shared/sleep";
-import { noPermissionError, notFoundError } from "api/errors";
-import { emailRoleIgnoreError } from 'api/sendgrid';
-import sequelizeInstance from 'api/database/sequelizeInstance';
+import { noPermissionError, notFoundError } from "../../api/errors";
+import { emailRoleIgnoreError } from '../../api/sendgrid';
+import sequelizeInstance from '../../api/database/sequelizeInstance';
 
 /**
  * Find the group meeting by the input group id. If the meeting is presented in OngoingMeetings model, return the

--- a/src/api/routes/partnerships.ts
+++ b/src/api/routes/partnerships.ts
@@ -13,11 +13,11 @@ import Assessment from "../database/models/Assessment";
 import { alreadyExistsError, generalBadRequestError, noPermissionError, notFoundError } from "../errors";
 import sequelizeInstance from "../database/sequelizeInstance";
 import { isPermitted } from "../../shared/Role";
-import Group from "api/database/models/Group";
+import Group from "../../api/database/models/Group";
 import { 
   defaultPartnershipAttributes,
   includeForGroup,
-  includeForPartnership } from "api/database/models/attributesAndIncludes";
+  includeForPartnership } from "../../api/database/models/attributesAndIncludes";
 import { createGroup } from "./groups";
 import invariant from "tiny-invariant";
 

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -8,7 +8,7 @@ import invariant from "tiny-invariant";
 import Group from "../database/models/Group";
 import { TRPCError } from "@trpc/server";
 import { safeDecodeMeetingSubject } from "./meetings";
-import apiEnv from "api/apiEnv";
+import apiEnv from "../../api/apiEnv";
 
 const crudeSummaryKey = "原始文字";
 

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import db from "../database/db";
 import { TRPCError } from "@trpc/server";
 import { isPermitted } from "../../shared/Role";
-import { zTranscript } from "shared/Transcript";
+import { zTranscript } from "../../shared/Transcript";
 import { includeForGroup } from "../database/models/attributesAndIncludes";
 
 const get = procedure

--- a/src/api/webhooks/index.ts
+++ b/src/api/webhooks/index.ts
@@ -1,4 +1,4 @@
-import apiEnv from "api/apiEnv";
+import apiEnv from "../../api/apiEnv";
 import { router } from "../trpc";
 import submitMenteeApplication from "./submitMenteeApplication";
 

--- a/src/components/AssessmentsPanel.tsx
+++ b/src/components/AssessmentsPanel.tsx
@@ -8,38 +8,38 @@ import {
 } from '@chakra-ui/react'
 import React from 'react'
 import { EditIcon } from '@chakra-ui/icons';
-import Loader from 'components/Loader';
+import Loader from '../components/Loader';
 import { useRouter } from 'next/router';
 import NextLink from "next/link";
-import Assessment from 'shared/Assessment';
-import trpc from 'trpc';
+import Assessment from '../shared/Assessment';
+import trpc from '../trpc';
 
-export default function AssessmentsPanel({ partnershipId, assessments, allowEdit } : {
+export default function AssessmentsPanel({ partnershipId, assessments, allowEdit }: {
   partnershipId: string,
   assessments: Assessment[] | undefined | null,
   allowEdit?: boolean,
 }) {
-  return !assessments ? 
-    <Loader /> 
-    : 
+  return !assessments ?
+    <Loader />
+    :
     <Table>
       <Tbody>
         {assessments.length > 0 ? assessments.map(a => (
           <AssessmentRow
-            key={a.id} 
-            partnershipId={partnershipId} 
+            key={a.id}
+            partnershipId={partnershipId}
             assessmentId={a.id}
             date={a.createdAt}
             summary={a.summary}
             allowEdit={allowEdit}
           />
         ))
-        : 
-        <AssessmentRow
-          partnershipId={partnershipId}
-          date={new Date()}
-          allowEdit={allowEdit}
-        />}
+          :
+          <AssessmentRow
+            partnershipId={partnershipId}
+            date={new Date()}
+            allowEdit={allowEdit}
+          />}
       </Tbody>
     </Table>;
 }
@@ -50,7 +50,7 @@ export function getYearText(date?: Date | string): string {
   return new Date(date).getFullYear() + "年度";
 }
 
-function AssessmentRow({ partnershipId, assessmentId, date, summary, allowEdit } : {
+function AssessmentRow({ partnershipId, assessmentId, date, summary, allowEdit }: {
   partnershipId: string,
   assessmentId?: string,  // When undefined, create a new assessment and enter the new assessment page.
   date?: Date | string,   // Optional merely to suppress typescript warning
@@ -68,8 +68,8 @@ function AssessmentRow({ partnershipId, assessmentId, date, summary, allowEdit }
     <Td>
       {getYearText(date)}
     </Td>
-    {summary ? 
-      <Td>{summary}</Td> : 
+    {summary ?
+      <Td>{summary}</Td> :
       <Td color="disabled">尚未评估</Td>
     }
     {allowEdit &&

--- a/src/components/Autosaver.tsx
+++ b/src/components/Autosaver.tsx
@@ -1,6 +1,6 @@
-import { useAutosaveContext } from 'AutosaveContext';
+import { useAutosaveContext } from '../AutosaveContext';
 import React, { useCallback, useEffect, useMemo } from 'react';
-import sleep from 'shared/sleep';
+import sleep from '../shared/sleep';
 
 const autosaveDelayMs = 500;
 const retryIntervalSec = 8;

--- a/src/components/GroupBar.tsx
+++ b/src/components/GroupBar.tsx
@@ -27,12 +27,12 @@ import trpc from "../trpc";
 import { MdVideocam } from 'react-icons/md';
 import Link from 'next/link';
 import { useUserContext } from 'UserContext';
-import { formatGroupName } from 'shared/strings';
+import { formatGroupName } from '../shared/strings';
 import ModalWithBackdrop from './ModalWithBackdrop';
 import { sidebarBreakpoint } from './Navbars';
 import UserChip from './UserChip';
-import { MinUser } from 'shared/User';
-import { Group, GroupCountingTranscripts, isOwned } from 'shared/Group';
+import { MinUser } from '../shared/User';
+import { Group, GroupCountingTranscripts, isOwned } from '../shared/Group';
 
 export default function GroupBar({
   group, showSelf, showJoinButton, showTranscriptCount, showTranscriptLink, abbreviateOnMobile, showGroupName, ...rest

--- a/src/components/Navbars.tsx
+++ b/src/components/Navbars.tsx
@@ -30,7 +30,7 @@ import { Guard, useGuard } from "@authing/guard-react18";
 import { useUserContext } from 'UserContext';
 import yuanjianLogo80x80 from '../../public/img/yuanjian-logo-80x80.png';
 import Image from "next/image";
-import colors from 'theme/colors';
+import colors from '../theme/colors';
 import AutosaveIndicator, { 
   AutosaveState,
   addPendingSaver,
@@ -38,9 +38,9 @@ import AutosaveIndicator, {
   removePendingSaver,
   setPendingSaverError
 } from './AutosaveIndicator';
-import AutosaveContext from 'AutosaveContext';
+import AutosaveContext from '../AutosaveContext';
 import Sidebar from './Sidebar';
-import { formatUserName } from 'shared/strings';
+import { formatUserName } from '../shared/strings';
 
 export const sidebarWidth = 60;
 export const topbarHeight = "60px";

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,14 +15,14 @@ import {
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { useUserContext } from 'UserContext';
-import { isPermitted } from 'shared/Role';
+import { isPermitted } from '../shared/Role';
 import yuanjianLogo224x97 from '../../public/img/yuanjian-logo-224x97.png';
 
 import Image from "next/image";
 import { useRouter } from 'next/router';
 import { MdChevronRight, MdFace } from 'react-icons/md';
-import { trpcNext } from 'trpc';
-import { Partnership } from 'shared/Partnership';
+import { trpcNext } from '../trpc';
+import { Partnership } from '../shared/Partnership';
 import {
   MdPerson,
   MdHome,
@@ -33,8 +33,8 @@ import {
 import Role from "../shared/Role";
 import { IconType } from "react-icons";
 import { sidebarBreakpoint, sidebarContentMarginTop, sidebarWidth, topbarHeight } from './Navbars';
-import { parseQueryParameter } from 'parseQueryParamter';
-import { formatUserName } from 'shared/strings';
+import { parseQueryParameter } from '../parseQueryParamter';
+import { formatUserName } from '../shared/strings';
 
 export interface SidebarItem {
   name: string,

--- a/src/components/UserChip.tsx
+++ b/src/components/UserChip.tsx
@@ -1,6 +1,6 @@
 import { Avatar, HStack, Text } from '@chakra-ui/react';
 import React from 'react';
-import { MinUser } from 'shared/User';
+import { MinUser } from '../shared/User';
 
 export default function UserChip(props: {
   user: MinUser;

--- a/src/pages/groups.tsx
+++ b/src/pages/groups.tsx
@@ -20,18 +20,18 @@ import {
   Checkbox
 } from '@chakra-ui/react'
 import React, { useState } from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../AppLayout'
 import { NextPageWithLayout } from '../NextPageWithLayout'
 import trpc from "../trpc";
 import { trpcNext } from "../trpc";
-import GroupBar from 'components/GroupBar';
-import UserChip from 'components/UserChip';
+import GroupBar from '../components/GroupBar';
+import UserChip from '../components/UserChip';
 import { Group } from '../shared/Group';
-import ModalWithBackdrop from 'components/ModalWithBackdrop';
+import ModalWithBackdrop from '../components/ModalWithBackdrop';
 import { MdPersonRemove } from 'react-icons/md';
-import { formatGroupName } from 'shared/strings';
+import { formatGroupName } from '../shared/strings';
 import { EditIcon } from '@chakra-ui/icons';
-import Loader from 'components/Loader';
+import Loader from '../components/Loader';
 import UserSelector from '../components/UserSelector';
 import QuestionIconTooltip from "../components/QuestionIconTooltip"
 

--- a/src/pages/groups/[groupId].tsx
+++ b/src/pages/groups/[groupId].tsx
@@ -18,11 +18,11 @@ import AppLayout from "../../AppLayout";
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { GroupWithTranscripts } from '../../shared/Group';
-import GroupBar from 'components/GroupBar';
+import GroupBar from '../../components/GroupBar';
 import { trpcNext } from "../../trpc";
-import PageBreadcrumb from 'components/PageBreadcrumb';
-import { prettifyDate, prettifyDuration } from 'shared/strings';
-import Loader from 'components/Loader';
+import PageBreadcrumb from '../../components/PageBreadcrumb';
+import { prettifyDate, prettifyDuration } from '../../shared/strings';
+import Loader from '../../components/Loader';
 import { MdChevronRight } from 'react-icons/md';
 import { parseQueryParameter } from '../../parseQueryParamter';
 

--- a/src/pages/groups/[groupId]/transcripts/[transcriptId].tsx
+++ b/src/pages/groups/[groupId]/transcripts/[transcriptId].tsx
@@ -12,15 +12,15 @@ import React, { useState } from 'react';
 import { NextPageWithLayout } from "../../../../NextPageWithLayout";
 import AppLayout from "../../../../AppLayout";
 import { trpcNext } from "../../../../trpc";
-import GroupBar from 'components/GroupBar';
+import GroupBar from '../../../../components/GroupBar';
 import { Transcript } from '../../../../shared/Transcript';
-import PageBreadcrumb from 'components/PageBreadcrumb';
+import PageBreadcrumb from '../../../../components/PageBreadcrumb';
 import { useRouter } from 'next/router';
 import invariant from 'tiny-invariant';
-import { prettifyDate, prettifyDuration } from 'shared/strings';
+import { prettifyDate, prettifyDuration } from '../../../../shared/strings';
 import { parseQueryParameter } from '../../../../parseQueryParamter';
-import MarkdownEditor from 'components/MarkdownEditor';
-import Loader from 'components/Loader';
+import MarkdownEditor from '../../../../components/MarkdownEditor';
+import Loader from '../../../../components/Loader';
 
 const Page: NextPageWithLayout = () => <TranscriptCard />;
 

--- a/src/pages/groups/lab.tsx
+++ b/src/pages/groups/lab.tsx
@@ -3,11 +3,11 @@ import {
   StackDivider
 } from '@chakra-ui/react'
 import React from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../../AppLayout'
 import { NextPageWithLayout } from '../../NextPageWithLayout'
 import { trpcNext } from "../../trpc";
-import GroupBar from 'components/GroupBar';
-import Loader from 'components/Loader';
+import GroupBar from '../../components/GroupBar';
+import Loader from '../../components/Loader';
 
 const Page: NextPageWithLayout = () => {
   const { data } = trpcNext.groups.listCountingTranscripts.useQuery({ userIds: [] });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,13 +18,13 @@ import AppLayout from "../AppLayout";
 import { useUserContext } from "../UserContext";
 import trpc from "../trpc";
 import { trpcNext } from "../trpc";
-import GroupBar from 'components/GroupBar';
-import PageBreadcrumb from 'components/PageBreadcrumb';
+import GroupBar from '../components/GroupBar';
+import PageBreadcrumb from '../components/PageBreadcrumb';
 import ConsentModal, { consentFormAccepted } from '../components/ConsentModal';
-import ModalWithBackdrop from 'components/ModalWithBackdrop';
+import ModalWithBackdrop from '../components/ModalWithBackdrop';
 import { isValidChineseName } from '../shared/strings';
-import Loader from 'components/Loader';
-import { isPermitted } from 'shared/Role';
+import Loader from '../components/Loader';
+import { isPermitted } from '../shared/Role';
 
 const Index: NextPageWithLayout = () => {
   const [user] = useUserContext();

--- a/src/pages/interviews.tsx
+++ b/src/pages/interviews.tsx
@@ -24,17 +24,17 @@ import {
   LinkBox,
 } from '@chakra-ui/react'
 import React, { useState } from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../AppLayout'
 import { NextPageWithLayout } from '../NextPageWithLayout'
 import { trpcNext } from "../trpc";
-import ModalWithBackdrop from 'components/ModalWithBackdrop';
-import trpc from 'trpc';
-import Loader from 'components/Loader';
-import UserSelector from 'components/UserSelector';
+import ModalWithBackdrop from './../components/ModalWithBackdrop';
+import trpc from '../trpc';
+import Loader from './../components/Loader';
+import UserSelector from './../components/UserSelector';
 import invariant from 'tiny-invariant';
-import { formatUserName, toPinyin } from 'shared/strings';
+import { formatUserName, toPinyin } from './../shared/strings';
 import { useRouter } from 'next/router';
-import { Interview, InterviewType } from 'shared/Interview';
+import { Interview, InterviewType } from './../shared/Interview';
 import { AddIcon } from '@chakra-ui/icons';
 
 const Page: NextPageWithLayout = () => {

--- a/src/pages/partnerships.tsx
+++ b/src/pages/partnerships.tsx
@@ -21,20 +21,20 @@ import {
   TableContainer,
 } from '@chakra-ui/react'
 import React, { useState } from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../AppLayout'
 import { NextPageWithLayout } from '../NextPageWithLayout'
 import { trpcNext } from "../trpc";
-import ModalWithBackdrop from 'components/ModalWithBackdrop';
-import trpc from 'trpc';
+import ModalWithBackdrop from '../components/ModalWithBackdrop';
+import trpc from '../trpc';
 import { AddIcon } from '@chakra-ui/icons';
-import Loader from 'components/Loader';
-import { PartnershipCountingAssessments, isValidPartnershipIds } from 'shared/Partnership';
-import UserSelector from 'components/UserSelector';
+import Loader from '../components/Loader';
+import { PartnershipCountingAssessments, isValidPartnershipIds } from '../shared/Partnership';
+import UserSelector from '../components/UserSelector';
 import invariant from 'tiny-invariant';
 import { useUserContext } from 'UserContext';
-import { isPermitted } from 'shared/Role';
+import { isPermitted } from '../shared/Role';
 import NextLink from 'next/link';
-import { formatUserName, toPinyin } from 'shared/strings';
+import { formatUserName, toPinyin } from '../shared/strings';
 
 const Page: NextPageWithLayout = () => {
   const [user] = useUserContext();

--- a/src/pages/partnerships/[partnershipId].tsx
+++ b/src/pages/partnerships/[partnershipId].tsx
@@ -1,15 +1,15 @@
-import AppLayout from 'AppLayout';
+import AppLayout from '../../AppLayout';
 import { NextPageWithLayout } from '../../NextPageWithLayout';
 import { useRouter } from 'next/router';
-import { parseQueryParameter } from 'parseQueryParamter';
-import trpc, { trpcNext } from 'trpc';
-import Loader from 'components/Loader';
+import { parseQueryParameter } from '../../parseQueryParamter';
+import trpc, { trpcNext } from '../../trpc';
+import Loader from '../../components/Loader';
 import { Flex, Grid, GridItem, Text, Tabs, TabList, TabPanels, Tab, TabPanel, Heading, Tooltip, Box, Center } from '@chakra-ui/react';
-import GroupBar from 'components/GroupBar';
-import { sidebarBreakpoint } from 'components/Navbars';
-import { AutosavingMarkdownEditor } from 'components/MarkdownEditor';
-import AssessmentsPanel from 'components/AssessmentsPanel';
-import { PrivateMentorNotes } from 'shared/Partnership';
+import GroupBar from '../../components/GroupBar';
+import { sidebarBreakpoint } from '../../components/Navbars';
+import { AutosavingMarkdownEditor } from '../../components/MarkdownEditor';
+import AssessmentsPanel from '../../components/AssessmentsPanel';
+import { PrivateMentorNotes } from '../../shared/Partnership';
 import { QuestionIcon } from '@chakra-ui/icons';
 
 const Page: NextPageWithLayout = () => {

--- a/src/pages/partnerships/[partnershipId]/assessments.tsx
+++ b/src/pages/partnerships/[partnershipId]/assessments.tsx
@@ -3,16 +3,16 @@ import {
   Divider,
 } from '@chakra-ui/react'
 import React from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../../../AppLayout'
 import { NextPageWithLayout } from '../../../NextPageWithLayout'
 import { trpcNext } from "../../../trpc";
-import Loader from 'components/Loader';
-import { PartnershipWithAssessments } from 'shared/Partnership';
+import Loader from '../../../components/Loader';
+import { PartnershipWithAssessments } from '../../../shared/Partnership';
 import { useRouter } from 'next/router';
 import { parseQueryParameter } from '../../../parseQueryParamter';
-import { UserChips } from 'components/GroupBar';
-import PageBreadcrumb from 'components/PageBreadcrumb';
-import AssessmentsPanel from 'components/AssessmentsPanel';
+import { UserChips } from '../../../components/GroupBar';
+import PageBreadcrumb from '../../../components/PageBreadcrumb';
+import AssessmentsPanel from '../../../components/AssessmentsPanel';
 
 const Page: NextPageWithLayout = () => {
   const partnershipId = parseQueryParameter(useRouter(), "partnershipId");

--- a/src/pages/partnerships/[partnershipId]/assessments/[assessmentId].tsx
+++ b/src/pages/partnerships/[partnershipId]/assessments/[assessmentId].tsx
@@ -2,14 +2,14 @@ import React, { useCallback } from 'react';
 import { NextPageWithLayout } from "../../../../NextPageWithLayout";
 import AppLayout from "../../../../AppLayout";
 import trpc, { trpcNext } from "../../../../trpc";
-import PageBreadcrumb from 'components/PageBreadcrumb';
+import PageBreadcrumb from '../../../../components/PageBreadcrumb';
 import { useRouter } from 'next/router';
 import { parseQueryParameter } from '../../../../parseQueryParamter';
-import Assessment from 'shared/Assessment';
-import Loader from 'components/Loader';
-import { AutosavingMarkdownEditor } from 'components/MarkdownEditor';
+import Assessment from '../../../../shared/Assessment';
+import Loader from '../../../../components/Loader';
+import { AutosavingMarkdownEditor } from '../../../../components/MarkdownEditor';
 import { Heading, Text, Flex } from '@chakra-ui/react';
-import { getYearText } from 'components/AssessmentsPanel';
+import { getYearText } from '../../../../components/AssessmentsPanel';
 
 const Page: NextPageWithLayout = () => <AssessmentEditor />;
 

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -15,14 +15,14 @@ import {
   SimpleGrid,
 } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../AppLayout'
 import { NextPageWithLayout } from '../NextPageWithLayout'
 import trpc from "../trpc";
 import { CheckIcon, CloseIcon, EditIcon, EmailIcon } from '@chakra-ui/icons';
 import { toast } from "react-toastify";
 import { useUserContext } from 'UserContext';
-import { isValidChineseName } from 'shared/strings';
-import Loader from 'components/Loader';
+import { isValidChineseName } from '../shared/strings';
+import Loader from '../components/Loader';
 
 // Dedupe code with index.tsx:SetNameModal
 const UserProfile: NextPageWithLayout = () => {

--- a/src/pages/users.tsx
+++ b/src/pages/users.tsx
@@ -26,17 +26,17 @@ import {
   TableContainer,
 } from '@chakra-ui/react'
 import React, { useState } from 'react'
-import AppLayout from 'AppLayout'
+import AppLayout from '../AppLayout'
 import { NextPageWithLayout } from '../NextPageWithLayout'
 import { trpcNext } from "../trpc";
-import User from 'shared/User';
-import ModalWithBackdrop from 'components/ModalWithBackdrop';
-import { isValidChineseName, toPinyin } from 'shared/strings';
-import Role, { AllRoles, RoleProfiles, isPermitted } from 'shared/Role';
-import trpc from 'trpc';
+import User from '../shared/User';
+import ModalWithBackdrop from '../components/ModalWithBackdrop';
+import { isValidChineseName, toPinyin } from '../shared/strings';
+import Role, { AllRoles, RoleProfiles, isPermitted } from '../shared/Role';
+import trpc from '../trpc';
 import { useUserContext } from 'UserContext';
 import { AddIcon, EditIcon } from '@chakra-ui/icons';
-import Loader from 'components/Loader';
+import Loader from '../components/Loader';
 import z from "zod";
 
 const Page: NextPageWithLayout = () => {

--- a/src/pages/whocanseemydata.tsx
+++ b/src/pages/whocanseemydata.tsx
@@ -10,11 +10,11 @@ import {
   Thead,
   Tbody,
 } from '@chakra-ui/react';
-import AppLayout from 'AppLayout';
+import AppLayout from '../AppLayout';
 import { NextPageWithLayout } from '../NextPageWithLayout';
 import { trpcNext } from "../trpc";
-import Loader from 'components/Loader';
-import PageBreadcrumb from 'components/PageBreadcrumb';
+import Loader from '../components/Loader';
+import PageBreadcrumb from '../components/PageBreadcrumb';
 import Role, { AllRoles, RoleProfiles } from '../shared/Role';
 
 const Page: NextPageWithLayout = () => {

--- a/src/shared/Transcript.ts
+++ b/src/shared/Transcript.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { zGroup } from "shared/Group";
+import { zGroup } from "../shared/Group";
 
 export const zTranscript = z.object({
     transcriptId: z.string(),


### PR DESCRIPTION
added `no-restricted-imports` rule to prevent users from importing project files (/src/*) as custom modules.
- Note that the paths and patterns of this rule are manually entered, so if any files or directories under src/ changed, they might also need to be updated in the rule