### PR TITLE
Add 'prepare' script to auto-sync db while deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "lint": "next lint",
     "nibble": "eslint-nibble --ext .jsx,.js,.tsx,.ts src",
     "cypress-run": "cypress run",
-    "cypress-open": "cypress open"
+    "cypress-open": "cypress open",
+    "prepare": "if [ \"$VERCEL_ENV\" = \"production\" ]; then ts-node tools/syncDatabase.ts; fi"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
a `prepare` script is added in `package.json` to automatically runs 'syncDatabase.ts' if the app is deploying on Vercel