### PR TITLE
Update Sentry config and environment variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -53,6 +53,3 @@ INTEGRATION_AUTH_TOKEN=
 # unauthorized Webhook invocation. Use a securely random string.
 # 
 WEBHOOK_TOKEN=
-
-# Auth Token for Sentry
-SENTRY_AUTH_TOKEN=

--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,7 @@ module.exports = withSentryConfig(
     silent: true,
 
     org: "visionary-education-foundation",
-    project: "javascript-nextjs",
+    project: "app",
   },
   {
     // For all available options, see:

--- a/next.config.js
+++ b/next.config.js
@@ -40,7 +40,7 @@ module.exports = withSentryConfig(
     tunnelRoute: "/monitoring",
 
     // Hides source maps from generated client bundles
-    hideSourceMaps: true,
+    hideSourceMaps: false,
 
     // Automatically tree-shake Sentry logger statements to reduce bundle size
     disableLogger: true,

--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ module.exports = withSentryConfig(
     widenClientFileUpload: true,
 
     // Transpiles SDK to be compatible with IE11 (increases bundle size)
-    transpileClientSDK: true,
+    transpileClientSDK: false,
 
     // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
     tunnelRoute: "/monitoring",

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -15,7 +15,12 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  environment: "production",
+  environment: process.env.NODE_ENV,
 
   tracePropagationTargets: ['localhost', /^\//],
+
+  ignoreErrors: [
+    'localhost',
+    // add any other domains or patterns you want to ignore
+  ],
 });

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -17,7 +17,7 @@ Sentry.init({
 
   environment: process.env.NODE_ENV,
 
-  tracePropagationTargets: ['localhost', /^\//],
+  tracePropagationTargets: [/^\//],
 
   ignoreErrors: [
     'localhost',

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  environment: "production",
+  environment: process.env.NODE_ENV,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -14,9 +14,14 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 
-  environment: "production",
+  environment: process.env.NODE_ENV,
 
   integrations: [
     new Integrations.Http({ tracing: true }),
+  ],
+
+  ignoreErrors: [
+    'localhost',
+    // add any other domains or patterns you want to ignore
   ],
 });


### PR DESCRIPTION
updated `next.config.js`
`environment` is adaptively changed to either "production" or "development"
`project` name is now changed to "app"
`SENTRY_AUTH_TOKEN` in `.env` is removed
`hideSourceMaps` is now `false`, sentry issues should show where the error happened in the source code. Further tests needed 
`ignoreErrors` is added to ignore any issues/errors from "localhost“

passed on developing both on local and Vercel