### PR TITLE
redirect "beta.yuanjian.org" to "yuantu.app"

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,7 +6,6 @@ import Head from 'next/head'
 import { trpcNext } from "../trpc";
 import { NextPageWithLayout } from "../NextPageWithLayout";
 import { ToastContainer } from "react-toastify";
-import { useEffect } from 'react'
 
 import '../app.css'
 import 'react-toastify/dist/ReactToastify.min.css';
@@ -15,14 +14,7 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout
 }
 
-function MyApp({ Component, pageProps }: AppPropsWithLayout) {
-  
-  useEffect(() => {
-    if (window.location.hostname === "beta.yuanjian.org") {
-      window.location.href = "https://yuantu.app";
-    }
-  }, []);
-
+function MyApp ({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || (page => page)
 
   return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import Head from 'next/head'
 import { trpcNext } from "../trpc";
 import { NextPageWithLayout } from "../NextPageWithLayout";
 import { ToastContainer } from "react-toastify";
+import { useEffect } from 'react'
 
 import '../app.css'
 import 'react-toastify/dist/ReactToastify.min.css';
@@ -14,7 +15,14 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout
 }
 
-function MyApp ({ Component, pageProps }: AppPropsWithLayout) {
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  
+  useEffect(() => {
+    if (window.location.hostname === "beta.yuanjian.org") {
+      window.location.href = "https://yuantu.app";
+    }
+  }, []);
+
   const getLayout = Component.getLayout || (page => page)
 
   return (

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,12 @@
       "path":"/api/v1/cron.updateOngoingMeetings",
       "schedule": "59 23 * * *"
     }
+  ],
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://yuantu.app/$1",
+      "permanent": true
+    }
   ]
 }


### PR DESCRIPTION
This method uses Vercel default config to redirect `beta.yuanjian.org` to `https://yuantu.app`, and seems most efficient approach on speed and resources  