### PR TITLE
Add event to notify admin when new users registered

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,7 @@ import SequelizeAdapter from "@auth/sequelize-adapter";
 import sequelizeInstance from "api/database/sequelizeInstance";
 import db from "../../../api/database/db";
 import { SendVerificationRequestParams } from "next-auth/providers";
-import { email as sendEmail } from "../../../api/sendgrid";
+import { email as sendEmail, emailRoleIgnoreError } from "../../../api/sendgrid";
 
 export const authOptions: NextAuthOptions = {
   adapter: SequelizeAdapter(sequelizeInstance, {
@@ -27,6 +27,12 @@ export const authOptions: NextAuthOptions = {
     signIn: '/auth/login',
     verifyRequest: '/auth/verify-request',
   },
+
+  events: {
+    createUser: async (message) => {
+      await emailRoleIgnoreError("UserManager", "新用户注册", `${message.user.email} 注册新用户 。`, "");
+    },
+  }
 };
 
 export default NextAuth(authOptions);


### PR DESCRIPTION
NextAuth.js `createUser` [Event ](https://next-auth.js.org/configuration/events)is used to monitor if the user is new and created by the adapter.

**Note:** There are a couple of alternative ways to achieve this function like using a `signIn` event. However, using `jwt callback` does not work, suspecting the reason being that we used an adapter that will change the `session` default `strategy` to be "database" instead of "jwt", see [details](https://next-auth.js.org/configuration/options#session)