### PR TITLE
Fix button hovering style

### DIFF
--- a/src/theme/buttons.ts
+++ b/src/theme/buttons.ts
@@ -10,6 +10,9 @@ const buttons = {
           color: "white",
           _hover: {
             bg: mode(colors.brand[600], colors.brand.c)(props),
+            _disabled: {
+              bg: mode(colors.brand[600], colors.brand.c)(props),
+            }
           },
         }),
       },


### PR DESCRIPTION
The `_hover` property was disabled if a `isDisabled` property was passed to the Button. 
The same color theme is passed to` _disabled` inside `_hover` and it should work now
[Login](https://drive.google.com/file/d/1nAiTxSu62tssKwh6HX6McUUcUvga_8bz/view) 
[User Management](https://drive.google.com/file/d/1qcEREXHBEAB4xxG0O4Imopck0SdTH7e4/view)