### PR TITLE
Extend next-auth session data to include user fields

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -26,19 +26,11 @@ export const authIntegration = () => middleware(async ({ ctx, next }) => {
 export const authUser = (permitted?: Role | Role[]) => middleware(async ({ ctx, next }) => {
   const session = await getServerSession(ctx.req, ctx.res, authOptions);
   if (!session) throw unauthorizedError();
-  const email = session.user?.email;
-  invariant(email);
 
-  // TODO: extend next-auth session data to include other user fields, and remove this extra call to db
-  const user = await db.User.findOne({
-    where: { email },
-    attributes: userAttributes,
-  });
-  invariant(user);
+  const roles = session.user?.roles;
+  if (!roles || !isPermitted(roles, permitted)) throw forbiddenError();
 
-  if (!isPermitted(user.roles, permitted)) throw forbiddenError();
-
-  return await next({ ctx: { user, baseUrl: ctx.baseUrl } });
+  return await next({ ctx: { user: session.user, baseUrl: ctx.baseUrl } });
 });
 
 const unauthorizedError = () => new TRPCError({

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -28,7 +28,8 @@ export const authUser = (permitted?: Role | Role[]) => middleware(async ({ ctx, 
   if (!session) throw unauthorizedError();
 
   const roles = session.user?.roles;
-  if (!roles || !isPermitted(roles, permitted)) throw forbiddenError();
+  invariant(roles);
+  if (!isPermitted(roles, permitted)) throw forbiddenError();
 
   return await next({ ctx: { user: session.user, baseUrl: ctx.baseUrl } });
 });

--- a/src/components/AppPageContainer.tsx
+++ b/src/components/AppPageContainer.tsx
@@ -6,30 +6,34 @@ import UserContext from "../UserContext";
 import User from '../shared/User';
 import NavBars, { sidebarBreakpoint, sidebarContentMarginTop, topbarHeight } from 'components/Navbars';
 import PageLoader from 'components/PageLoader';
-import { useSession } from 'next-auth/react';
+import { getSession } from 'next-auth/react';
 
 export default function AppPageContainer({ children, wide, ...rest }: {
   wide: boolean
 } & PropsWithChildren) {
   const [user, setUser] = useState<User | null>(null);
-  const { data: session } = useSession();
 
   useEffect(() => {
-    if (session) {
-      setUser(session.user);
-    }
-  }, [session]);
+    const fetchSession = async () => {
+      const session = await getSession();
+      if (session) {
+        setUser(session.user);
+      }
+    };
+
+    fetchSession();
+  }, []);
 
   return !user ?
     <PageLoader {...rest} />
-    : 
+    :
     <UserContext.Provider value={[user, setUser]}>
       <NavBars {...rest}>
         <Box
           marginTop={sidebarContentMarginTop}
-          paddingX={{ 
+          paddingX={{
             base: "16px",
-            [sidebarBreakpoint]: "30px" 
+            [sidebarBreakpoint]: "30px"
           }}
           maxWidth={{
             base: "100%",
@@ -39,7 +43,7 @@ export default function AppPageContainer({ children, wide, ...rest }: {
           minHeight={{
             base: `calc(100vh - ${topbarHeight} - (140px + ${footerMarginTop}))`,
             [footerBreakpoint]: `calc(100vh - ${topbarHeight} - (95px + ${footerMarginTop}))`,
-          }}      
+          }}
         >
           {children}
         </Box>

--- a/src/components/AppPageContainer.tsx
+++ b/src/components/AppPageContainer.tsx
@@ -9,39 +9,32 @@ import PageLoader from 'components/PageLoader';
 import { Session } from 'next-auth';
 
 export default function AppPageContainer({ children, wide, session, ...rest }: {
-  wide: boolean
-} & PropsWithChildren & {session: Session}) {
-  const [user, setUser] = useState<User | null>(null);
-
-  useEffect(() => {
-    const f = async () => { setUser(session.user); };
-    f();
-  }, [session]);
-
-  return !user ?
-    <PageLoader {...rest} />
-    :
-    <UserContext.Provider value={[user, setUser]}>
-      <NavBars {...rest}>
-        <Box
-          marginTop={sidebarContentMarginTop}
-          paddingX={{
-            base: "16px",
-            [sidebarBreakpoint]: "30px"
-          }}
-          maxWidth={{
-            base: "100%",
-            ...!wide && { xl: "1200px" }
-          }}
-          // TODO: these hard-coded numbers are empirically measured footer heights. Replace them with constants.
-          minHeight={{
-            base: `calc(100vh - ${topbarHeight} - (140px + ${footerMarginTop}))`,
-            [footerBreakpoint]: `calc(100vh - ${topbarHeight} - (95px + ${footerMarginTop}))`,
-          }}
-        >
-          {children}
-        </Box>
-        <Footer />
-      </NavBars>
-    </UserContext.Provider>;
+  wide: boolean,
+  session: Session
+} & PropsWithChildren) {
+  const [user, setUser] = useState<User>(session.user);
+  
+  return <UserContext.Provider value={[user, setUser]}>
+    <NavBars {...rest}>
+      <Box
+        marginTop={sidebarContentMarginTop}
+        paddingX={{
+          base: "16px",
+          [sidebarBreakpoint]: "30px"
+        }}
+        maxWidth={{
+          base: "100%",
+          ...!wide && { xl: "1200px" }
+        }}
+        // TODO: these hard-coded numbers are empirically measured footer heights. Replace them with constants.
+        minHeight={{
+          base: `calc(100vh - ${topbarHeight} - (140px + ${footerMarginTop}))`,
+          [footerBreakpoint]: `calc(100vh - ${topbarHeight} - (95px + ${footerMarginTop}))`,
+        }}
+      >
+        {children}
+      </Box>
+      <Footer />
+    </NavBars>
+  </UserContext.Provider>;
 }

--- a/src/components/AppPageContainer.tsx
+++ b/src/components/AppPageContainer.tsx
@@ -6,23 +6,17 @@ import UserContext from "../UserContext";
 import User from '../shared/User';
 import NavBars, { sidebarBreakpoint, sidebarContentMarginTop, topbarHeight } from 'components/Navbars';
 import PageLoader from 'components/PageLoader';
-import { getSession } from 'next-auth/react';
+import { Session } from 'next-auth';
 
-export default function AppPageContainer({ children, wide, ...rest }: {
+export default function AppPageContainer({ children, wide, session, ...rest }: {
   wide: boolean
-} & PropsWithChildren) {
+} & PropsWithChildren & {session: Session}) {
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
-    const fetchSession = async () => {
-      const session = await getSession();
-      if (session) {
-        setUser(session.user);
-      }
-    };
-
-    fetchSession();
-  }, []);
+    const f = async () => { setUser(session.user); };
+    f();
+  }, [session]);
 
   return !user ?
     <PageLoader {...rest} />

--- a/src/components/AppPageContainer.tsx
+++ b/src/components/AppPageContainer.tsx
@@ -3,21 +3,23 @@ import Footer, { footerBreakpoint, footerMarginTop } from 'components/Footer';
 import { PropsWithChildren, useEffect, useState } from 'react';
 
 import UserContext from "../UserContext";
-import trpc from "../trpc";
 import User from '../shared/User';
 import NavBars, { sidebarBreakpoint, sidebarContentMarginTop, topbarHeight } from 'components/Navbars';
 import PageLoader from 'components/PageLoader';
+import { useSession } from 'next-auth/react';
 
 export default function AppPageContainer({ children, wide, ...rest }: {
   wide: boolean
 } & PropsWithChildren) {
   const [user, setUser] = useState<User | null>(null);
+  const { data: session } = useSession();
 
   // TODO: extend next-auth session data to include other user fields, and remove this extra call to users.me
   useEffect(() => {
-    const f = async () => setUser(await trpc.users.me.query());
-    f();
-  }, []);
+    if (session) {
+      setUser(session.user); // You'll have the extended session data here
+    }
+  }, [session]);
 
   return !user ?
     <PageLoader {...rest} />

--- a/src/components/AppPageContainer.tsx
+++ b/src/components/AppPageContainer.tsx
@@ -14,10 +14,9 @@ export default function AppPageContainer({ children, wide, ...rest }: {
   const [user, setUser] = useState<User | null>(null);
   const { data: session } = useSession();
 
-  // TODO: extend next-auth session data to include other user fields, and remove this extra call to users.me
   useEffect(() => {
     if (session) {
-      setUser(session.user); // You'll have the extended session data here
+      setUser(session.user);
     }
   }, [session]);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -51,7 +51,6 @@ function App({ Component, pageProps: { session, ...pageProps } }: {
 export default trpcNext.withTRPC(App);
 
 function SwitchBoard({ children, wide, ...rest }: PropsWithChildren & { wide: boolean}) {
-  // TODO: combine what userSession().data returns and our own User object.
   const { data: session, status } = useSession();
   const router = useRouter();
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,9 +50,9 @@ function App({ Component, pageProps: { session, ...pageProps } }: {
 
 export default trpcNext.withTRPC(App);
 
-function SwitchBoard({ children, wide, ...rest }: PropsWithChildren & { wide: boolean }) {
+function SwitchBoard({ children, wide, ...rest }: PropsWithChildren & { wide: boolean}) {
   // TODO: combine what userSession().data returns and our own User object.
-  const { status } = useSession();
+  const { data: session, status } = useSession();
   const router = useRouter();
 
   const isAuthPage = router.asPath.startsWith("/auth/");
@@ -72,7 +72,7 @@ function SwitchBoard({ children, wide, ...rest }: PropsWithChildren & { wide: bo
       router.replace("/");
       return null;
     } else {
-      return <AppPageContainer wide={wide} {...rest}>{children}</AppPageContainer>;
+      return <AppPageContainer wide={wide} session={session} {...rest}>{children}</AppPageContainer>;
     }
   }
 }

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -10,6 +10,7 @@ import { userAttributes } from "api/database/models/attributesAndIncludes";
 import invariant from "tiny-invariant";
 import User from "api/database/models/User";
 
+// The default session user would cause type error when using session user data
 declare module "next-auth" {
   interface Session {
     user: User;

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -6,6 +6,15 @@ import { SendVerificationRequestParams } from "next-auth/providers";
 import { email as sendEmail, emailRoleIgnoreError } from "../../../api/sendgrid";
 import randomNumber from "random-number-csprng";
 import { toChinese } from "shared/strings";
+import { userAttributes } from "api/database/models/attributesAndIncludes";
+import invariant from "tiny-invariant";
+import User from "api/database/models/User";
+
+declare module "next-auth" {
+  interface Session {
+    user: User;
+  }
+}
 
 const tokenMaxAgeInMins = 5;
 
@@ -33,6 +42,19 @@ export const authOptions: NextAuthOptions = {
     signIn: '/auth/login',
     // The login page respects the `?error=` URL param.
     error: '/auth/login',
+  },
+
+  callbacks: {
+    async session({ session }) {
+      const user = await db.User.findOne({
+        where: { email: session.user.email },
+        attributes: userAttributes,
+      });
+      invariant(user);
+      session.user = user;
+
+      return session;
+    }
   },
 
   events: {


### PR DESCRIPTION
- User data is included in the next-auth session and should be available by calling `useSession` instead of a `trpc.user.me query`.
- Type of `session.user` is declared as the `User` model.
- The website functions as normal including user login and new user signup.
- TODO: optimize redundant APIs and db calls with session data, such as removing trpc.user.me.query, and other unnecessary codes. Also check TODOs in auth.ts