### PR TITLE
Create name mapping model

### DIFF
--- a/src/api/database/db.ts
+++ b/src/api/database/db.ts
@@ -15,6 +15,7 @@ import Calibration from "./models/Calibration";
 import InterviewFeedbackUpdateAttempt from "./models/InterviewFeedbackUpdateAttempt";
 import ChatThread from "./models/ChatThread";
 import ChatMessage from "./models/ChatMessage";
+import NameMapping from "./models/TranscriptNameMapping";
 
 const db = {
   Partnership,
@@ -31,6 +32,7 @@ const db = {
   Calibration,
   ChatThread,
   ChatMessage,
+  NameMapping
 };
 
 export default db;

--- a/src/api/database/db.ts
+++ b/src/api/database/db.ts
@@ -15,15 +15,15 @@ import Calibration from "./models/Calibration";
 import InterviewFeedbackUpdateAttempt from "./models/InterviewFeedbackUpdateAttempt";
 import ChatThread from "./models/ChatThread";
 import ChatMessage from "./models/ChatMessage";
-import NameMapping from "./models/TranscriptNameMapping";
+import TranscriptNameMapping from "./models/TranscriptNameMapping";
 
 const db = {
   Partnership,
   User,
-  Group, 
-  GroupUser, 
-  Transcript, 
-  Summary, 
+  Group,
+  GroupUser,
+  Transcript,
+  Summary,
   OngoingMeetings,
   Assessment,
   Interview,
@@ -32,7 +32,7 @@ const db = {
   Calibration,
   ChatThread,
   ChatMessage,
-  NameMapping
+  TranscriptNameMapping,
 };
 
 export default db;

--- a/src/api/database/models/TranscriptNameMapping.ts
+++ b/src/api/database/models/TranscriptNameMapping.ts
@@ -5,7 +5,6 @@ import {
   ForeignKey,
   BelongsTo,
   PrimaryKey,
-  AllowNull,
 } from 'sequelize-typescript';
 import { UUID, STRING } from 'sequelize';
 import User from './User';
@@ -27,7 +26,6 @@ class TranscriptNameMapping extends Model {
 
   @Column(UUID)
   @ForeignKey(() => User)
-  @AllowNull(false)
   userId: string;
 
   /**

--- a/src/api/database/models/TranscriptNameMapping.ts
+++ b/src/api/database/models/TranscriptNameMapping.ts
@@ -23,7 +23,7 @@ import {
   
     @Column(UUID)
     @ForeignKey(() => User)
-    userId: string;
+    userId: string | null;
 
     // Associations
     @BelongsTo(() => User)

--- a/src/api/database/models/TranscriptNameMapping.ts
+++ b/src/api/database/models/TranscriptNameMapping.ts
@@ -1,34 +1,40 @@
 import {
-    Table,
-    Column,
-    Model,
-    ForeignKey,
-    BelongsTo,
-    PrimaryKey,
-  } from 'sequelize-typescript';
-  import { UUID, STRING } from 'sequelize';
-  import User from './User';
-  import Transcript from "./Transcript";
+  Table,
+  Column,
+  Model,
+  ForeignKey,
+  BelongsTo,
+  PrimaryKey,
+  AllowNull,
+} from 'sequelize-typescript';
+import { UUID, STRING } from 'sequelize';
+import User from './User';
+import Transcript from "./Transcript";
 
-  @Table({ paranoid: true })
-  class NameMapping extends Model {
-    @PrimaryKey
-    @Column(STRING)
-    handlebarName: string;
+/*
+* This table maps user names with handlebars(Tencent Meeting User Name) in transcripts/summaries
+*/
+@Table
+class TranscriptNameMapping extends Model {
+  @PrimaryKey
+  @Column(STRING)
+  handlebarName: string;
 
-    @PrimaryKey
-    @ForeignKey(() => Transcript)
-    @Column(STRING)
-    transcriptId: string;
-  
-    @Column(UUID)
-    @ForeignKey(() => User)
-    userId: string | null;
+  @PrimaryKey
+  @ForeignKey(() => Transcript)
+  @Column(STRING)
+  transcriptId: string;
 
-    // Associations
-    @BelongsTo(() => User)
-    user: User;
-  }
-  
-  export default NameMapping;
-  
+  @Column(UUID)
+  @ForeignKey(() => User)
+  @AllowNull(false)
+  userId: string;
+
+  /**
+   * Associations
+   */
+  @BelongsTo(() => User)
+  user: User;
+}
+
+export default TranscriptNameMapping;

--- a/src/api/database/models/TranscriptNameMapping.ts
+++ b/src/api/database/models/TranscriptNameMapping.ts
@@ -1,0 +1,34 @@
+import {
+    Table,
+    Column,
+    Model,
+    ForeignKey,
+    BelongsTo,
+    PrimaryKey,
+  } from 'sequelize-typescript';
+  import { STRING } from 'sequelize';
+  import User from './User';
+  import Transcript from "./Transcript";
+
+  @Table({ paranoid: true })
+  class NameMapping extends Model {
+    @PrimaryKey
+    @Column(STRING)
+    handlebarName: string;
+
+    @PrimaryKey
+    @ForeignKey(() => Transcript)
+    @Column(STRING)
+    transcriptId: string;
+  
+    @ForeignKey(() => User)
+    @Column(STRING)
+    userId: string;
+  
+    // Associations
+    @BelongsTo(() => User)
+    user: User;
+  }
+  
+  export default NameMapping;
+  

--- a/src/api/database/models/TranscriptNameMapping.ts
+++ b/src/api/database/models/TranscriptNameMapping.ts
@@ -19,11 +19,6 @@ class TranscriptNameMapping extends Model {
   @Column(STRING)
   handlebarName: string;
 
-  @PrimaryKey
-  @ForeignKey(() => Transcript)
-  @Column(STRING)
-  transcriptId: string;
-
   @Column(UUID)
   @ForeignKey(() => User)
   userId: string;

--- a/src/api/database/models/TranscriptNameMapping.ts
+++ b/src/api/database/models/TranscriptNameMapping.ts
@@ -6,7 +6,7 @@ import {
     BelongsTo,
     PrimaryKey,
   } from 'sequelize-typescript';
-  import { STRING } from 'sequelize';
+  import { UUID, STRING } from 'sequelize';
   import User from './User';
   import Transcript from "./Transcript";
 
@@ -21,10 +21,10 @@ import {
     @Column(STRING)
     transcriptId: string;
   
+    @Column(UUID)
     @ForeignKey(() => User)
-    @Column(STRING)
     userId: string;
-  
+
     // Associations
     @BelongsTo(() => User)
     user: User;


### PR DESCRIPTION
The name mapping model is associated with transcript IDs so it is unique per transcript and could apply to all the summaries under the associated transcript. Group IDs are not used since the group members could change.