### PR TITLE
modify handlebar backend api

### DIFF
--- a/src/api/database/db.ts
+++ b/src/api/database/db.ts
@@ -15,7 +15,7 @@ import Calibration from "./models/Calibration";
 import InterviewFeedbackUpdateAttempt from "./models/InterviewFeedbackUpdateAttempt";
 import ChatRoom from "./models/ChatRoom";
 import ChatMessage from "./models/ChatMessage";
-import SummaryNameMap from "./models/SummaryNameMap";
+import TranscriptNameMap from "./models/TranscriptNameMap";
 
 const db = {
   Partnership,
@@ -32,7 +32,7 @@ const db = {
   Calibration,
   ChatRoom,
   ChatMessage,
-  SummaryNameMap,
+  TranscriptNameMap,
 };
 
 export default db;

--- a/src/api/database/models/TranscriptNameMap.ts
+++ b/src/api/database/models/TranscriptNameMap.ts
@@ -8,13 +8,12 @@ import {
 } from 'sequelize-typescript';
 import { UUID, STRING } from 'sequelize';
 import User from './User';
-import Transcript from "./Transcript";
 
 /*
 * This table maps user names with handlebars(Tencent Meeting User Name) in transcripts/summaries
 */
 @Table
-class SummaryNameMap extends Model {
+class TranscriptNameMap extends Model {
   @PrimaryKey
   @Column(STRING)
   handlebarName: string;
@@ -30,4 +29,4 @@ class SummaryNameMap extends Model {
   user: User;
 }
 
-export default SummaryNameMap;
+export default TranscriptNameMap;

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -82,18 +82,15 @@ const list = procedure
   const { nameMap, summaries } = await getSummariesAndNameMap(transcriptId);
 
   // create a mapping object of { [handlebars]: [userNames] } for handlebar.js to compile
-  let handlebarInput : Record<string, string> = {};
+  const handlebarInput : Record<string, string> = {};
   for (const nm of nameMap) {
-    if(nm.user){
-      handlebarInput[nm.handlebarName] = `**${nm.user.name}**`;
-    }else{
-      handlebarInput[nm.handlebarName] = `**${nm.handlebarName}**`;
-  }}
+    handlebarInput[nm.handlebarName] = `**${nm.user ? nm.user.name : nm.handlebarName}**`;
+  }
 
   for (const summary of summaries) {
     try {
       // Compile and update summary
-      summary.summary = Handlebars.compile(summary.summary)(nameMap);
+      summary.summary = Handlebars.compile(summary.summary)(handlebarInput);
     } catch (error) {
       // If there's an error compiling, keep and return the original summaries
       console.error("Error compiling Handlebars template for summary:", summary.transcriptId, summary.summaryKey);

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -12,7 +12,7 @@ import { zSummary } from "shared/Summary";
 import { notFoundError } from "api/errors";
 import { checkPermissionForGroup } from "./groups";
 import Handlebars from "handlebars";
-import { getSummariesAndNameMap } from "./transcripts";
+import { getSummariesAndUserMap } from "./transcripts";
 
 const crudeSummaryKey = "原始文字";
 
@@ -79,7 +79,7 @@ const list = procedure
 
   checkPermissionForGroup(ctx.user, t.group);
 
-  const { nameMap, summaries } = await getSummariesAndNameMap(transcriptId);
+  const { nameMap, summaries } = await getSummariesAndUserMap(transcriptId);
 
   for (const summary of summaries) {
     summary.summary = Handlebars.compile(summary.summary)(nameMap);

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -12,7 +12,7 @@ import { zSummary } from "shared/Summary";
 import { notFoundError } from "api/errors";
 import { checkPermissionForGroup } from "./groups";
 import Handlebars from "handlebars";
-import { getSummariesAndUserMap } from "./transcripts";
+import { getSummariesAndNameMap } from "./transcripts";
 
 const crudeSummaryKey = "原始文字";
 
@@ -79,10 +79,19 @@ const list = procedure
 
   checkPermissionForGroup(ctx.user, t.group);
 
-  const { nameMap, summaries } = await getSummariesAndUserMap(transcriptId);
+  const { nameMap, summaries } = await getSummariesAndNameMap(transcriptId);
+
+  // create a mapping object of { [handlebars]: [userNames] } for handlebar.js to compile
+  let handlebarInput : Record<string, string> = {};
+  for (const nm of nameMap) {
+    if(nm.user){
+      handlebarInput[nm.handlebarName] = `**${nm.user.name}**`;
+    }else{
+      handlebarInput[nm.handlebarName] = `**${nm.handlebarName}**`;
+  }}
 
   for (const summary of summaries) {
-    summary.summary = Handlebars.compile(summary.summary)(nameMap);
+    summary.summary = Handlebars.compile(summary.summary)(handlebarInput);
   }
 
   return summaries;

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -14,7 +14,7 @@ import { checkPermissionForGroup } from "./groups";
 import invariant from 'tiny-invariant';
 import { Op } from "sequelize";
 import Summary from "api/database/models/Summary";
-import { zSummaryNameMap } from "shared/Summary";
+import { zTranscriptNameMap } from "shared/Summary";
 
 const list = procedure
   .use(authUser())
@@ -56,7 +56,7 @@ const getMostRecentStartedAt = procedure
 const getUserMap = procedure
   .use(authUser())
   .input(z.object({ transcriptId: z.string() }))
-  .output(z.array(zSummaryNameMap))
+  .output(z.array(zTranscriptNameMap))
   .query(async ({ input }) =>
 {
   const { userMap } = await getSummariesAndUserMap(input.transcriptId);
@@ -68,7 +68,7 @@ const getUserMap = procedure
  */
 const updateUserMap = procedure
   .use(authUser())
-  .input(z.array(zSummaryNameMap))
+  .input(z.array(zTranscriptNameMap))
   .mutation(async ({ input: userMap }) =>
 {
   // Construct an array of objects to upsert multiple rows the same time
@@ -78,7 +78,7 @@ const updateUserMap = procedure
       userId,
     }));
 
-  await db.SummaryNameMap.bulkCreate(upsertArray, { updateOnDuplicate: ['userId'] });
+  await db.TranscriptNameMap.bulkCreate(upsertArray, { updateOnDuplicate: ['userId'] });
 });
 
 export default router({
@@ -121,7 +121,7 @@ export async function getSummariesAndUserMap(transcriptId: string): Promise<{
     nameMap[handlebar] = `**${handlebar}**`;
   }
 
-  const snm = await db.SummaryNameMap.findAll({
+  const snm = await db.TranscriptNameMap.findAll({
     where: { handlebarName: [...handlebarsSet] },
     include: [{
       model: db.User,

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -8,12 +8,14 @@ import {
   groupAttributes,
   groupInclude,
   transcriptAttributes,
-  summaryAttributes
+  summaryAttributes,
+  minUserAttributes
 } from "api/database/models/attributesAndIncludes";
 import { checkPermissionForGroup } from "./groups";
 import { Op } from "sequelize";
 import Summary from "api/database/models/Summary";
 import { zTranscriptNameMap, TranscriptNameMap } from "shared/Transcript";
+import invariant from 'tiny-invariant';
 
 const list = procedure
   .use(authUser())
@@ -114,7 +116,7 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
     where: { handlebarName: [...handlebarsSet] },
     include: [{
       model: db.User,
-      attributes: ['name','id'],
+      attributes: minUserAttributes,
       where: { name: { [Op.ne]: null } } // Ensure user's name is not null
     }],
   });
@@ -126,11 +128,11 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
   for (const handlebar of [...handlebarsSet]) {
     const entries = tnm.filter(e => e.handlebarName === handlebar);
     if (entries.length) {
-      const mappedEntries = entries.map(e => ({
-        handlebarName: e.handlebarName,
-        user: e.user.dataValues
-      }));
-      nameMap.push(...mappedEntries);
+      invariant(entries.length === 1);
+      nameMap.push({
+        handlebarName: entries[0].handlebarName,
+        user: entries[0].dataValues.user.dataValues,
+      });
     } else {
       nameMap.push({ handlebarName: handlebar, user: null });
     }

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -14,7 +14,7 @@ import { checkPermissionForGroup } from "./groups";
 import invariant from 'tiny-invariant';
 import { Op } from "sequelize";
 import Summary from "api/database/models/Summary";
-import { zTranscriptNameMap } from "shared/Summary";
+import { zTranscriptNameMap } from "shared/Transcript";
 
 const list = procedure
   .use(authUser())
@@ -60,7 +60,7 @@ const getUserMap = procedure
   .query(async ({ input }) =>
 {
   const { userMap } = await getSummariesAndUserMap(input.transcriptId);
-  return userMap;
+  return [userMap];
 });
 
 /**

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -68,7 +68,10 @@ const getUserMap = procedure
  */
 const updateUserMap = procedure
   .use(authUser())
-  .input(z.array(zTranscriptNameMap))
+  .input(z.array(z.object({
+    handlebarName: z.string(),
+    userId: z.string(),
+  })))
   .mutation(async ({ input: userMap }) =>
 {
   // Construct an array of objects to upsert multiple rows the same time

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -14,7 +14,7 @@ import { checkPermissionForGroup } from "./groups";
 import invariant from 'tiny-invariant';
 import { Op } from "sequelize";
 import Summary from "api/database/models/Summary";
-import { zTranscriptNameMap } from "shared/Transcript";
+import { zTranscriptNameMap, TranscriptNameMap } from "shared/Transcript";
 
 const list = procedure
   .use(authUser())
@@ -88,15 +88,9 @@ export default router({
   updateUserMap,
 });
 
-/**
- * Retrieves summaries and generates name and ID mappings based on the handlebars within those summaries.
- * @returns {Summary[]} result.summaries - An array of fetched summaries.
- * @returns {Record<string, string>} result.nameMap - A mapping from handlebars to names.
- * @returns {SummaryNameMap[]} result.userMap - A mapping from handlebars to user IDs and names.
- */
 export async function getSummariesAndUserMap(transcriptId: string): Promise<{
   summaries: Summary[],
-  nameMap: Record<string, string>,
+  nameMap: TranscriptNameMap,
   userMap: typeof snm,
 }> {
   const summaries = await db.Summary.findAll({

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -125,12 +125,11 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
   // if not, create an object of this handlebar with null user, 
   // otherwise when Handlebars.js compile it will return empty
   for (const handlebar of [...handlebarsSet]) {
-    nameMap.forEach(nm => {
-      if (nm.handlebarName !== handlebar) {
-        nameMap.push({ handlebarName: handlebar, user: null });
-      }
-    });
+    if (![...nameMap].some(nm => nm.handlebarName === handlebar)) {
+      nameMap.push({ handlebarName: handlebar, user: null });
+    }
   }
 
+  console.log(nameMap);
   return { summaries, nameMap };
 }

--- a/src/shared/Summary.ts
+++ b/src/shared/Summary.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { zMinUser } from './User';
 
 export const zSummary = z.object({
   transcriptId: z.string(),
@@ -8,8 +7,3 @@ export const zSummary = z.object({
 });
 
 export type Summary = z.TypeOf<typeof zSummary>;
-
-export const zTranscriptNameMap = z.object({
-  handlebarName: z.string(),
-  user: zMinUser,
-});

--- a/src/shared/Summary.ts
+++ b/src/shared/Summary.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { zMinUser } from './User';
 
 export const zSummary = z.object({
     transcriptId: z.string(),
@@ -7,3 +8,9 @@ export const zSummary = z.object({
   });
 
 export type Summary = z.TypeOf<typeof zSummary>;
+
+export const zSummaryNameMap = z.object({
+  handlebarName: z.string(),
+  userId: z.string(),
+  user: zMinUser,
+});

--- a/src/shared/Summary.ts
+++ b/src/shared/Summary.ts
@@ -2,15 +2,14 @@ import { z } from 'zod';
 import { zMinUser } from './User';
 
 export const zSummary = z.object({
-    transcriptId: z.string(),
-    summaryKey: z.string(),
-    summary: z.string(),
-  });
+  transcriptId: z.string(),
+  summaryKey: z.string(),
+  summary: z.string(),
+});
 
 export type Summary = z.TypeOf<typeof zSummary>;
 
-export const zSummaryNameMap = z.object({
+export const zTranscriptNameMap = z.object({
   handlebarName: z.string(),
-  userId: z.string(),
   user: zMinUser,
 });

--- a/src/shared/Transcript.ts
+++ b/src/shared/Transcript.ts
@@ -11,7 +11,7 @@ export type Transcript = z.TypeOf<typeof zTranscript>;
 
 export const zTranscriptNameMap = z.array(z.object({
   handlebarName: z.string(),
-  user: zMinUser,
+  user: zMinUser.nullable(),
 }));
 
 export type TranscriptNameMap = z.TypeOf<typeof zTranscriptNameMap>;

--- a/src/shared/Transcript.ts
+++ b/src/shared/Transcript.ts
@@ -11,6 +11,8 @@ export type Transcript = z.TypeOf<typeof zTranscript>;
 
 export const zTranscriptNameMap = z.array(z.object({
   handlebarName: z.string(),
+   // Object user will be null if the handlebarName is not linked to any users
+   // check routes/transcripts/getSummariesAndNameMap for details
   user: zMinUser.nullable(),
 }));
 

--- a/src/shared/Transcript.ts
+++ b/src/shared/Transcript.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { zMinUser } from './User';
 
 export const zTranscript = z.object({
   startedAt: z.coerce.string(),
@@ -7,3 +8,8 @@ export const zTranscript = z.object({
 });
 
 export type Transcript = z.TypeOf<typeof zTranscript>;
+
+export const zTranscriptNameMap = z.array(z.object({
+  handlebarName: z.string(),
+  user: zMinUser,
+}));

--- a/src/shared/Transcript.ts
+++ b/src/shared/Transcript.ts
@@ -13,3 +13,5 @@ export const zTranscriptNameMap = z.array(z.object({
   handlebarName: z.string(),
   user: zMinUser,
 }));
+
+export type TranscriptNameMap = z.TypeOf<typeof zTranscriptNameMap>;


### PR DESCRIPTION
- The APIs and functions named using `NameMap` are changed to `UserMap` for a more accurate description. 
- UserMap consists of a `zSummaryNameMap` type of `{ [handlebar]:  string, [userId]: string, [user]: MinUser }` which will be passed and used at the frontend. 
- `NameMap` is retained for its utility with summary.list. This ensures compatibility with handlebar.js when rendering summary texts.