### PR TITLE
Fix handlebar corner case 

### DIFF
--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -81,8 +81,15 @@ const list = procedure
 
   const { nameMap, summaries } = await getSummariesAndNameMap(transcriptId);
 
-  for (const summary of summaries) {
-    summary.summary = Handlebars.compile(summary.summary)(nameMap);
+  try {
+    for (const summary of summaries) {
+      // Compile and update summary
+      summary.summary = Handlebars.compile(summary.summary)(nameMap);
+    }
+  } catch (error) {
+    console.error("Error compiling Handlebars template:", error);
+    // If there's an error, just return the original summaries
+    return summaries;
   }
 
   return summaries;

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -81,15 +81,14 @@ const list = procedure
 
   const { nameMap, summaries } = await getSummariesAndNameMap(transcriptId);
 
-  try {
-    for (const summary of summaries) {
+  for (const summary of summaries) {
+    try {
       // Compile and update summary
       summary.summary = Handlebars.compile(summary.summary)(nameMap);
+    } catch (error) {
+      // If there's an error compiling, keep and return the original summaries
+      console.error("Error compiling Handlebars template for summary:", summary.transcriptId + summary.summaryKey);
     }
-  } catch (error) {
-    console.error("Error compiling Handlebars template:", error);
-    // If there's an error, just return the original summaries
-    return summaries;
   }
 
   return summaries;

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -87,7 +87,7 @@ const list = procedure
       summary.summary = Handlebars.compile(summary.summary)(nameMap);
     } catch (error) {
       // If there's an error compiling, keep and return the original summaries
-      console.error("Error compiling Handlebars template for summary:", summary.transcriptId + summary.summaryKey);
+      console.error("Error compiling Handlebars template for summary:", summary.transcriptId, summary.summaryKey);
     }
   }
 

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -100,8 +100,11 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
   let handlebarsSet = new Set<string>();
 
   for (let s of summaries) {
-    const matches = extractHandlebars(s.summary);
-    matches.forEach(handlebar => handlebarsSet.add(handlebar));
+    const matches = s.summary.match(/{{(.*?)}}/g);
+    if (matches) {
+      const extracted = matches.map(match => match.slice(2, -2));
+      extracted.forEach(handlebar => handlebarsSet.add(handlebar));
+    }
   }
 
   const nameMap: Record<string, string> = {};
@@ -125,33 +128,4 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
   }
 
   return { summaries, nameMap };
-}
-
-// extract the handlebars and only the outmost ones if a nested is presented
-function extractHandlebars(text: string) {
-  let stack = [];
-  let start = -1;
-  let handlebars = [];
-
-  for (let i = 0; i < text.length; i++) {
-    if (text[i] === "{" && text[i + 1] === "{") {
-      stack.push("{{");
-      if (stack.length === 1) { // outermost {{
-        start = i;
-      }
-      i++;
-    }
-    else if (text[i] === "}" && text[i + 1] === "}") {
-      if (stack.length > 0 && stack[stack.length - 1] === "{{") {
-        stack.pop();
-        if (stack.length === 0 && start !== -1) {
-          handlebars.push(text.substring(start + 2, i).trim());
-          start = -1;
-        }
-      }
-      i++;
-    }
-  }
-
-  return handlebars;
 }

--- a/src/api/routes/transcripts.ts
+++ b/src/api/routes/transcripts.ts
@@ -100,11 +100,8 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
   let handlebarsSet = new Set<string>();
 
   for (let s of summaries) {
-    const matches = s.summary.match(/{{(.*?)}}/g);
-    if (matches) {
-      const extracted = matches.map(match => match.slice(2, -2));
-      extracted.forEach(handlebar => handlebarsSet.add(handlebar));
-    }
+    const matches = extractHandlebars(s.summary);
+    matches.forEach(handlebar => handlebarsSet.add(handlebar));
   }
 
   const nameMap: Record<string, string> = {};
@@ -128,4 +125,33 @@ export async function getSummariesAndNameMap(transcriptId: string): Promise<{
   }
 
   return { summaries, nameMap };
+}
+
+// extract the handlebars and only the outmost ones if a nested is presented
+function extractHandlebars(text: string) {
+  let stack = [];
+  let start = -1;
+  let handlebars = [];
+
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "{" && text[i + 1] === "{") {
+      stack.push("{{");
+      if (stack.length === 1) { // outermost {{
+        start = i;
+      }
+      i++;
+    }
+    else if (text[i] === "}" && text[i + 1] === "}") {
+      if (stack.length > 0 && stack[stack.length - 1] === "{{") {
+        stack.pop();
+        if (stack.length === 0 && start !== -1) {
+          handlebars.push(text.substring(start + 2, i).trim());
+          start = -1;
+        }
+      }
+      i++;
+    }
+  }
+
+  return handlebars;
 }


### PR DESCRIPTION
- A try-catch block is added to the `summaries.list` to return the original summary text if handlebars.js is having errors compiling.
- The regex method to find handlebars are replaced with a stack method