### PR TITLE
Add markdown styler to correctly render Markdown texts using Chakra UI

### DIFF
--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -15,12 +15,12 @@ import { componentSpacing, paragraphSpacing } from 'theme/metrics';
 import trpc, { trpcNext } from 'trpc';
 import { formatUserName, prettifyDate } from 'shared/strings';
 import moment from 'moment';
-import ReactMarkdown from 'react-markdown';
 import { MdEdit, MdSend } from 'react-icons/md';
 import { useUserContext } from 'UserContext';
 import { AddIcon } from '@chakra-ui/icons';
 import invariant from "tiny-invariant";
 import Loader from './Loader';
+import MarkdownStyler from './MarkdownStyler';
 
 export default function Room({ menteeId } : {
   menteeId: string,
@@ -76,7 +76,7 @@ function Message({ message: m }: {
       </HStack>
 
       {editing ? <Editor message={m} onClose={() => setEditing(false)} /> :
-        <ReactMarkdown>{m.markdown}</ReactMarkdown>}
+        <MarkdownStyler content={m.markdown} />}
     </VStack>
   </HStack>;
 }

--- a/src/components/MarkdownStyler.tsx
+++ b/src/components/MarkdownStyler.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import styles from '../theme/MarkdownStyler.module.css';
+
+// This component is to correctly render Markdowns when using chakra UI
+// Chakra UI CSSReset component is turning down browser default style of elements
+// https://stackoverflow.com/a/64317290
+const MarkdownStyler = ({ content }: { content: string }) => (
+  <div className={styles.markdownStyler}>
+    <ReactMarkdown>{content}</ReactMarkdown>
+  </div>
+);
+
+export default MarkdownStyler;

--- a/src/components/Transcripts.tsx
+++ b/src/components/Transcripts.tsx
@@ -15,11 +15,11 @@ import invariant from 'tiny-invariant';
 import { diffInMinutes, prettifyDate, prettifyDuration } from 'shared/strings';
 import { parseQueryString } from "shared/strings";
 import Loader from 'components/Loader';
-import ReactMarkdown from 'react-markdown';
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
 import { componentSpacing, sectionSpacing } from 'theme/metrics';
 import replaceUrlParam from 'shared/replaceUrlParam';
 import { sidebarBreakpoint } from 'components/Navbars';
+import MarkdownStyler from './MarkdownStyler';
 
 export default function Transcripts({ groupId }: {
   groupId: string
@@ -94,7 +94,7 @@ function LoadedTranscripts({ transcripts: unsorted }: {
       {!summary ? <Loader /> :
         <Card variant="outline" backgroundColor="backgroundLight">
           <CardBody>
-            <ReactMarkdown>{summary.summary}</ReactMarkdown>
+            <MarkdownStyler content={summary.summary} />
           </CardBody>
         </Card>
       }

--- a/src/theme/MarkdownStyler.module.css
+++ b/src/theme/MarkdownStyler.module.css
@@ -1,0 +1,28 @@
+.markdownStyler h1,
+.markdownStyler h2,
+.markdownStyler h3,
+.markdownStyler h4 {
+  font-weight: bold;
+  margin-top: 1.2em;
+  margin-bottom: 1em;
+}
+
+.markdownStyler h1 {
+  font-size: 1.75em;
+}
+
+.markdownStyler h2 {
+  font-size: 1.5em;
+}
+
+.markdownStyler h3 {
+  font-size: 1.25em;
+}
+
+.markdownStyler h4 {
+  font-size: 1.1em;
+}
+
+.markdownStyler p {
+  margin: 0.5em 0;
+}


### PR DESCRIPTION
The Chakra UI CSSReset component would override the default styles of elements provided by the browsers, which could cause markdown texts not to display correctly as shown below.

![image](https://github.com/yuanjian-org/app/assets/83266861/db4bf765-d34d-4bd0-b835-a77f6f9125c2)

A markdown styler component has been added with customized component styles to resolve this problem.

![2f919868fcbb71cde109ef5aa190c07](https://github.com/yuanjian-org/app/assets/83266861/0d8f1222-4df5-4264-9efa-79caa5acaab5)
