### PR TITLE
Comment on remark-gfm to support GitHub Flavored Markdown(GFM)

### DIFF
--- a/src/components/MarkdownStyler.tsx
+++ b/src/components/MarkdownStyler.tsx
@@ -5,6 +5,10 @@ import styles from '../theme/MarkdownStyler.module.css';
 // This component is to correctly render Markdowns when using chakra UI
 // Chakra UI CSSReset component is turning down browser default style of elements
 // https://stackoverflow.com/a/64317290
+//
+// To enable and render GFM such as strikethrough or footnote in the future
+// Add & use remark-gfm as plugin shown in the link below
+// https://github.com/remarkjs/react-markdown?tab=readme-ov-file#use
 const MarkdownStyler = ({ content }: { content: string }) => (
   <div className={styles.markdownStyler}>
     <ReactMarkdown>{content}</ReactMarkdown>


### PR DESCRIPTION
[issue 272](https://github.com/yuanjian-org/app/issues/272) reported that strikethrough is not recognized correctly. 

According to react-markdown official, the original dependency does not support strikethrough, so the plugin [remark-gfm](https://github.com/remarkjs/remark-gfm) is added and used as [shown in the README.](https://github.com/remarkjs/react-markdown?tab=readme-ov-file#use)

Now strikethrough is working properly as shown below
![1715453434482](https://github.com/yuanjian-org/app/assets/83266861/6c05ec42-1329-4abc-944f-7e243acd438b)
