### PR TITLE
fix: fix toast error fails to show during network disconnection on login

### DIFF
--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -53,8 +53,9 @@ export default function Login() {
         router.push(`/auth/verify`);
       }
     } catch (err) {
-      console.error(`Unkonwn error on sign-in: ${err}`);
-      toast.error(`糟糕，系统错误，请联系管理员：${err}`);
+      const msg = `糟糕，系统错误，请联系管理员：${err}`;
+      console.error(msg);
+      toast.error(msg);
     } finally {
       setIsLoading(false);
     }

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -52,6 +52,9 @@ export default function Login() {
         localStorage.setItem(localStorageKeyForLoginEmail, email);
         router.push(`/auth/verify`);
       }
+    } catch (err) {
+      console.error(`Unkonwn error on sign-in: ${err}`);
+      toast.error(`糟糕，系统错误，请联系管理员：${err}`);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
This issue is related to [issue 92](https://github.com/yuanjian-org/app/issues/92)

Currently, if we are disconnected from database and the user tries to log in, the toast is not displayed properly when the backend server returns error code 500.
<img width="1466" alt="current" src="https://github.com/yuanjian-org/app/assets/122472773/15f0bd09-7c8d-48e4-beeb-3fb16aecce96">

Now, the toast error message is displayed as intended.
<img width="1468" alt="modify" src="https://github.com/yuanjian-org/app/assets/122472773/1d82a33d-8e22-47fd-91a3-82cdd87a0b4b">