### PR TITLE
feat: allow single-member groups

### DIFF
--- a/src/api/routes/groups.ts
+++ b/src/api/routes/groups.ts
@@ -17,7 +17,7 @@ import User from "shared/User";
 const create = procedure
   .use(authUser('GroupManager'))
   .input(z.object({
-    userIds: z.array(z.string()).min(2),
+    userIds: z.array(z.string()).min(1),
   }))
   .mutation(async ({ ctx, input }) =>
 {

--- a/src/pages/groups.tsx
+++ b/src/pages/groups.tsx
@@ -66,12 +66,12 @@ export default function Page() {
 
     <Wrap spacing={6}>
       <WrapItem minWidth={100} alignItems="center">
-        <UserSelector isMulti placeholder="按用户过滤，或为创建分组输入两名或以上用户" onSelect={setUserIds} />
+        <UserSelector isMulti placeholder="按用户过滤，或为创建分组输入一名或以上用户" onSelect={setUserIds} />
       </WrapItem>
       <WrapItem alignItems="center">
         <Button
           isLoading={creating}
-          isDisabled={userIds.length < 2}
+          isDisabled={userIds.length < 1}
           loadingText='创建分组中...'
           variant='brand' onClick={createGroup}>
           创建自由分组
@@ -114,7 +114,7 @@ function GroupEditor({ group, onClose }: {
   const [working, setWorking] = useState(false);
   const [confirmingDeletion, setConfirmingDeletion] = useState(false);
 
-  const isValid = users.length + newUserIds.length > 1;
+  const isValid = users.length + newUserIds.length > 0;
 
   const save = async () => {
     setWorking(true);
@@ -205,7 +205,7 @@ function GroupEditor({ group, onClose }: {
               </FormControl>
             )}
             <FormControl isInvalid={!isValid}>
-              <FormErrorMessage>需要至少两名用户。</FormErrorMessage>
+              <FormErrorMessage>需要至少一名用户。</FormErrorMessage>
             </FormControl>
           </VStack>
         </ModalBody>


### PR DESCRIPTION
This pr is related to [issue 241](https://github.com/yuanjian-org/app/issues/241)
Currently, the system enforces that each group must have two or more members:
![Screenshot 2024-05-23 at 11 46 27](https://github.com/yuanjian-org/app/assets/122472773/a11fea6d-a1e1-4f54-b92f-daceb8c1f725)

The create group button (创建自由分组) is disabled if there is only one user entered:
![Screenshot 2024-05-23 at 11 46 59](https://github.com/yuanjian-org/app/assets/122472773/8947dba1-bf41-41f8-b36b-51e83c59d0be)

The single-member group edit window shows an error message: "需要至少两名用户" (At least two users are required):
![Screenshot 2024-05-23 at 11 46 36](https://github.com/yuanjian-org/app/assets/122472773/27054fa2-e333-4888-80d4-14ba5a148710)

Now, the system allows single-member groups:
![Screenshot 2024-05-23 at 11 50 29](https://github.com/yuanjian-org/app/assets/122472773/6db8cf09-f0bf-41d5-97b1-b199fb3232ef)
![Screenshot 2024-05-23 at 11 49 53](https://github.com/yuanjian-org/app/assets/122472773/cc22904a-d2ae-40da-a32a-1c9d28c6f84f)
![Screenshot 2024-05-23 at 11 49 17](https://github.com/yuanjian-org/app/assets/122472773/c844565f-0dec-4870-9140-cfa3e7a5c6a5)
![Screenshot 2024-05-23 at 11 51 33](https://github.com/yuanjian-org/app/assets/122472773/a33bd44b-8d34-46fd-82e4-693b6e8f99e4)
![Screenshot 2024-05-23 at 12 16 22](https://github.com/yuanjian-org/app/assets/122472773/6f44b493-b5a1-48a8-a460-bc76338ff725)


