### PR TITLE
Fix #280: download speaker duration summary from tencentmeeting and display it on transcript UI

### DIFF
--- a/src/api/TencentMeeting.ts
+++ b/src/api/TencentMeeting.ts
@@ -272,7 +272,7 @@ export async function getFileAddresses(recordFileId: string, tmUserId: string) {
 }
 
 // https://cloud.tencent.com/document/product/1095/105659
-async function getSmartSpeakers(recordFileId: string, tmUserId: string) {
+export async function getSmartSpeakers(recordFileId: string, tmUserId: string) {
   console.log( `getSmartSpeakers("${recordFileId}")`);
 
   const zRes = z.object({
@@ -296,7 +296,7 @@ async function getSmartSpeakers(recordFileId: string, tmUserId: string) {
     speaker.total_time = millisecondsToMinutes(speaker.total_time);
   }
 
-  return res;
+  return res.speaker_list;
 }; 
 
 function decodeBase64(base64: string): string {

--- a/src/api/TencentMeeting.ts
+++ b/src/api/TencentMeeting.ts
@@ -271,5 +271,41 @@ export async function getFileAddresses(recordFileId: string, tmUserId: string) {
   return res;
 }
 
+// https://cloud.tencent.com/document/product/1095/105659
+async function getSmartSpeakers(recordFileId: string, tmUserId: string) {
+  console.log( `getSmartSpeakers("${recordFileId}")`);
+
+  const zRes = z.object({
+    speaker_list: z.array(z.object({
+    speaker_name: z.string(),
+    total_time: z.number(),
+    }))
+  });
+
+  const res = zRes.parse(await tmRequest('GET', 
+  `/v1/smart/speakers`, {
+    'record_file_id': recordFileId,
+    'operator_id_type': 1,
+    'operator_id': tmUserId,
+    'page_size':50,
+    'page':1
+  }));
+
+  for(const speaker of res.speaker_list){
+    speaker.speaker_name = decodeBase64(speaker.speaker_name);
+    speaker.total_time = millisecondsToMinutes(speaker.total_time);
+  }
+
+  return res;
+}; 
+
+function decodeBase64(base64: string): string {
+  return Buffer.from(base64, 'base64').toString('utf-8');
+}
+
+function millisecondsToMinutes(milliseconds: number): number {
+  return Math.round(milliseconds / 60000);
+}
+
 // Uncomment and modify this line to debug TM APIs.
 // listRecords().then(res => console.log(JSON.stringify(res, null, 2)));

--- a/src/api/TencentMeeting.ts
+++ b/src/api/TencentMeeting.ts
@@ -273,7 +273,9 @@ export async function getFileAddresses(recordFileId: string, tmUserId: string) {
 }
 
 // https://cloud.tencent.com/document/product/1095/105659
-export async function getSpeakerStats(recordFileId: string, tmUserId: string) {
+export async function getSpeakerStats(recordFileId: string, tmUserId: string):
+  Promise<SpeakerStats>
+{
   console.log(LOG_HEADER, `getSpeakerStats("${recordFileId}")`);
 
   const zRes = z.object({
@@ -292,8 +294,8 @@ export async function getSpeakerStats(recordFileId: string, tmUserId: string) {
   const speakerList : SpeakerStats = [];
   for (const speaker of res.speaker_list) {
     speakerList.push({
-      speaker_name: decodeBase64(speaker.speaker_name),
-      total_time: millisecondsToMinutes(speaker.total_time),
+      speakerName: decodeBase64(speaker.speakerName),
+      totalTime: millisecondsToMinutes(speaker.totalTime),
     });
   }
 

--- a/src/api/routes/summaries.ts
+++ b/src/api/routes/summaries.ts
@@ -150,7 +150,7 @@ async function findMissingCrudeSummariesforTmUser(tmUserId: string,
           addrs.ai_minutes) {
           const spkrList = await getSmartSpeakers(file.record_file_id, tmUserId);
           spkrList.sort((a, b) => b.total_time - a.total_time);
-          let spkrInfo = "发言时长统计（分钟): ";
+          let spkrInfo = "*发言时长统计（分钟)*: ";
           spkrList.forEach((spkr, index) => {
             spkrInfo += `${spkr.speaker_name}:${spkr.total_time}`;
             if (index < spkrList.length - 1) {

--- a/src/shared/Summary.ts
+++ b/src/shared/Summary.ts
@@ -9,8 +9,8 @@ export const zSummary = z.object({
 export type Summary = z.TypeOf<typeof zSummary>;
 
 export const zSpeakerStats = z.array(z.object({
-  speaker_name: z.string(),
-  total_time: z.number(),
+  speakerName: z.string(),
+  totalTime: z.number(),
 }));
 
 export type SpeakerStats = z.infer<typeof zSpeakerStats>;

--- a/src/shared/Summary.ts
+++ b/src/shared/Summary.ts
@@ -7,3 +7,10 @@ export const zSummary = z.object({
 });
 
 export type Summary = z.TypeOf<typeof zSummary>;
+
+export const zSpeakerStats = z.array(z.object({
+  speaker_name: z.string(),
+  total_time: z.number(),
+}));
+
+export type SpeakerStats = z.infer<typeof zSpeakerStats>;


### PR DESCRIPTION
- A new Tencent Meeting API has been integrated to fetch speaker names and speech times per meeting. Two utility functions were added to decode usernames from Base64 and convert speech times from milliseconds to minutes.
- In `summaries.ts`, the `summaryKey` property of `SummaryDescriptor` has been updated to `summaryDetails`, which now includes both summary keywords and speaker details.
   - In `findMissingCrudeSummariesforTmUser`, the function will now fetch and store speaker information after confirming the availability of AI minutes for the specific transcript summaries.