### PR TITLE
Added creation date in chatroom note

### DIFF
--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -22,7 +22,7 @@ import invariant from "tiny-invariant";
 import Loader from './Loader';
 import MarkdownStyler from './MarkdownStyler';
 
-export default function Room({ menteeId } : {
+export default function Room({ menteeId }: {
   menteeId: string,
 }) {
   const { data: room } = trpcNext.chat.getRoom.useQuery({ menteeId });
@@ -36,7 +36,7 @@ export default function Room({ menteeId } : {
         .map(m => <Message key={m.id} message={m} />)
       }
     </VStack>
-  ;
+    ;
 }
 
 function MessageCreator({ roomId }: {
@@ -47,7 +47,7 @@ function MessageCreator({ roomId }: {
   return editing ?
     <Editor roomId={roomId} onClose={() => setEditing(false)}
       marginTop={componentSpacing} />
-    : 
+    :
     <Button variant="outline" leftIcon={<AddIcon />}
       onClick={() => setEditing(true)}>新消息</Button>;
 }
@@ -65,8 +65,8 @@ function Message({ message: m }: {
       <HStack minWidth="210px" spacing={componentSpacing}>
         <Text>{name}</Text>
         <Text color="grey">
-          {m.updatedAt && prettifyDate(m.updatedAt)}
-          {m.updatedAt !== m.createdAt && "更新"}
+          {m.createdAt && `${prettifyDate(m.createdAt)}创建`}
+          {m.updatedAt && m.updatedAt !== m.createdAt && ` ｜ ${prettifyDate(m.updatedAt)}更新`}
         </Text>
 
         {!editing && user.id == m.user.id && <>
@@ -110,7 +110,7 @@ function Editor({ roomId, message, onClose, ...rest }: {
 
   return <>
     <Textarea value={markdown} onChange={e => setMarkdown(e.target.value)}
-      autoFocus background="white" height={200} {...rest} 
+      autoFocus background="white" height={200} {...rest}
     />
     <HStack>
       <Button onClick={save} isLoading={saving} isDisabled={!markdown}


### PR DESCRIPTION
Fixed #295 
If the note has been updated, both the creation date and the last modification date will be shown. 
If the note has not been updated, only the creation date will be displayed

Previous:
<img width="517" alt="Screenshot 2024-07-03 at 15 03 02" src="https://github.com/yuanjian-org/app/assets/122472773/5683c081-990b-4894-ae0f-e0eeacd5f2b7">
After change:
<img width="670" alt="Screenshot 2024-07-03 at 15 09 25" src="https://github.com/yuanjian-org/app/assets/122472773/46ced087-c8b3-4d12-9a69-a59782f3d6b5">
