### PR TITLE
Move auto-save indicator to the center and stick at the top

### DIFF
--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -20,7 +20,13 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
               {errors.length > 0 ? (
                 <><WarningIcon {...iconProps} color="red" /><Text fontSize="sm" color="red">{errors[0].toString()}</Text></>
               ) : (
-                <><RepeatIcon {...iconProps} color="disabled" /><Text fontSize="sm" color="disabled" style={{ textShadow: "1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white" }}>保存中...</Text></>
+                <><RepeatIcon {...iconProps} color="disabled" stroke="white" strokeWidth="1px" />
+                  <Text fontSize="sm" color="disabled" style={{
+                    textShadow: `
+                    1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white,
+                    1px 1px 0 white, -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white,
+                    1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white`}}>保存中...</Text>
+                </>
               )}
             </Center>
           </motion.div>
@@ -28,7 +34,11 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
       ) : state.virgin ? null :
         <motion.div initial={{ opacity: 1 }} animate={{ opacity: 0 }} transition={{ duration: 3 }}>
           <Center {...rest}>
-            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="green" style={{ textShadow: "1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white" }}>已保存</Text>
+            <CheckIcon {...iconProps} color="green" stroke="white" strokeWidth="1px" /><Text fontSize="sm" color="green" style={{
+              textShadow: `
+              1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white,
+              1px 1px 0 white, -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white,
+              1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white`}}>已保存</Text>
           </Center>
         </motion.div>
       }

--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -20,7 +20,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
               {errors.length > 0 ? (
                 <><WarningIcon {...iconProps} color="red" /><Text fontSize="sm" color="red">{errors[0].toString()}</Text></>
               ) : (
-                <><RepeatIcon {...iconProps} color="disabled" stroke="white" strokeWidth="1px" />
+                <><RepeatIcon {...iconProps} color="disabled" />
                   <Text fontSize="sm" color="disabled" style={{
                     textShadow: `
                     1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white,
@@ -34,7 +34,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
       ) : state.virgin ? null :
         <motion.div initial={{ opacity: 1 }} animate={{ opacity: 0 }} transition={{ duration: 3 }}>
           <Center {...rest}>
-            <CheckIcon {...iconProps} color="green" stroke="white" strokeWidth="1px" /><Text fontSize="sm" color="green" style={{
+            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="green" style={{
               textShadow: `
               1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white,
               1px 1px 0 white, -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white,

--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -25,7 +25,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
                     textShadow: `
                     1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white,
                     1px 1px 0 white, -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white,
-                    1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white`}}>保存中...</Text>
+                    1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white` }}>保存中...</Text>
                 </>
               )}
             </Center>
@@ -38,7 +38,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
               textShadow: `
               1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white,
               1px 1px 0 white, -1px -1px 0 white, 1px -1px 0 white, -1px 1px 0 white,
-              1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white`}}>已保存</Text>
+              1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white` }}>已保存</Text>
           </Center>
         </motion.div>
       }

--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, RepeatIcon, WarningIcon } from '@chakra-ui/icons';
-import { Center, CenterProps, Text } from '@chakra-ui/react';
+import { Center, CenterProps, Text, Box } from '@chakra-ui/react';
 import React, { useEffect } from 'react';
 import invariant from "tiny-invariant";
 import { motion } from "framer-motion";
@@ -10,23 +10,30 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
 }) {
   const errors = [...state.id2state.values()].filter(v => v !== null);
   const iconProps = { boxSize: 3.5, marginRight: 2, };
-  return hasPendingSavers(state) ? <>
-    <LeavePagePrompt />
-    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
-      <Center {...rest}>
-        {errors.length > 0 ?
-          <><WarningIcon {...iconProps} color="red"/><Text fontSize="sm" color="red">{errors[0].toString()}</Text></>
-          :
-          <><RepeatIcon {...iconProps} color="disabled"/><Text fontSize="sm" color="disabled">保存中...</Text></>
-        }
-      </Center>
-    </motion.div>
-  </> : state.virgin ? null : 
-    <motion.div initial={{ opacity: 1 }} animate={{ opacity: 0 }} transition={{ duration: 3 }}>
-      <Center {...rest}>
-        <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="green">已保存</Text>
-      </Center>
-    </motion.div>;
+  return (
+    <Box position="fixed" top="10px" left="10px" right="0" zIndex="sticky">
+      {hasPendingSavers(state) ? (
+        <>
+          <LeavePagePrompt />
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
+            <Center {...rest}>
+              {errors.length > 0 ? (
+                <><WarningIcon {...iconProps} color="red" /><Text fontSize="sm" color="red">{errors[0].toString()}</Text></>
+              ) : (
+                <><RepeatIcon {...iconProps} color="disabled" /><Text fontSize="sm" color="disabled">保存中...</Text></>
+              )}
+            </Center>
+          </motion.div>
+        </>
+      ) : state.virgin ? null :
+        <motion.div initial={{ opacity: 1 }} animate={{ opacity: 0 }} transition={{ duration: 3 }}>
+          <Center {...rest}>
+            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="green">已保存</Text>
+          </Center>
+        </motion.div>
+      }
+    </Box>
+  );
 }
 
 /**

--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -11,7 +11,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
   const errors = [...state.id2state.values()].filter(v => v !== null);
   const iconProps = { boxSize: 3.5, marginRight: 2, };
   return (
-    <Box position="fixed" top="10px" right="2%" zIndex="2">
+    <Box position="fixed" top="60px" right="5%" zIndex="2">
       {hasPendingSavers(state) ? (
         <>
           <LeavePagePrompt />
@@ -20,7 +20,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
               {errors.length > 0 ? (
                 <><WarningIcon {...iconProps} color="red" /><Text fontSize="sm" color="red">{errors[0].toString()}</Text></>
               ) : (
-                <><RepeatIcon {...iconProps} color="disabled" /><Text fontSize="sm" color="disabled">保存中...</Text></>
+                <><RepeatIcon {...iconProps} color="disabled" /><Text fontSize="sm" color="white" background="grey" padding="2" borderRadius="md">保存中...</Text></>
               )}
             </Center>
           </motion.div>
@@ -28,7 +28,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
       ) : state.virgin ? null :
         <motion.div initial={{ opacity: 1 }} animate={{ opacity: 0 }} transition={{ duration: 3 }}>
           <Center {...rest}>
-            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="green">已保存</Text>
+            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="white" background="green" padding="2" borderRadius="md">已保存</Text>
           </Center>
         </motion.div>
       }

--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -20,7 +20,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
               {errors.length > 0 ? (
                 <><WarningIcon {...iconProps} color="red" /><Text fontSize="sm" color="red">{errors[0].toString()}</Text></>
               ) : (
-                <><RepeatIcon {...iconProps} color="disabled" /><Text fontSize="sm" color="white" background="grey" padding="2" borderRadius="md">保存中...</Text></>
+                <><RepeatIcon {...iconProps} color="disabled" /><Text fontSize="sm" color="disabled" style={{ textShadow: "1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white" }}>保存中...</Text></>
               )}
             </Center>
           </motion.div>
@@ -28,7 +28,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
       ) : state.virgin ? null :
         <motion.div initial={{ opacity: 1 }} animate={{ opacity: 0 }} transition={{ duration: 3 }}>
           <Center {...rest}>
-            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="white" background="green" padding="2" borderRadius="md">已保存</Text>
+            <CheckIcon {...iconProps} color="green" /><Text fontSize="sm" color="green" style={{ textShadow: "1px 0 0 white, -1px 0 0 white, 0 1px 0 white, 0 -1px 0 white" }}>已保存</Text>
           </Center>
         </motion.div>
       }

--- a/src/components/AutosaveIndicator.tsx
+++ b/src/components/AutosaveIndicator.tsx
@@ -11,7 +11,7 @@ export default function AutosaveIndicator({ state, ...rest }: CenterProps & {
   const errors = [...state.id2state.values()].filter(v => v !== null);
   const iconProps = { boxSize: 3.5, marginRight: 2, };
   return (
-    <Box position="fixed" top="10px" left="10px" right="0" zIndex="sticky">
+    <Box position="fixed" top="10px" right="2%" zIndex="2">
       {hasPendingSavers(state) ? (
         <>
           <LeavePagePrompt />

--- a/src/components/MobileExperienceAlert.tsx
+++ b/src/components/MobileExperienceAlert.tsx
@@ -3,7 +3,7 @@ import { sidebarBreakpoint } from 'components/Navbars';
 
 
 export default function MobileExperienceAlert(props: AlertProps) {
-  return <Alert status="warning" width="89%" display={{ [sidebarBreakpoint]: "none" }} {...props}>
+  return <Alert status="warning" maxWidth="75%" maxdisplay={{ [sidebarBreakpoint]: "none" }} {...props}>
     <HStack>
       <AlertIcon />
       <AlertDescription>本页内容较多。为了最佳使用体验，建议使用桌面浏览器。</AlertDescription>

--- a/src/components/MobileExperienceAlert.tsx
+++ b/src/components/MobileExperienceAlert.tsx
@@ -3,7 +3,7 @@ import { sidebarBreakpoint } from 'components/Navbars';
 
 
 export default function MobileExperienceAlert(props: AlertProps) {
-  return <Alert status="warning" maxWidth="75%" maxdisplay={{ [sidebarBreakpoint]: "none" }} {...props}>
+  return <Alert status="warning" maxWidth="75%" top="-12px" maxdisplay={{ [sidebarBreakpoint]: "none" }} {...props}>
     <HStack>
       <AlertIcon />
       <AlertDescription>本页内容较多。为了最佳使用体验，建议使用桌面浏览器。</AlertDescription>

--- a/src/components/MobileExperienceAlert.tsx
+++ b/src/components/MobileExperienceAlert.tsx
@@ -3,7 +3,7 @@ import { sidebarBreakpoint } from 'components/Navbars';
 
 
 export default function MobileExperienceAlert(props: AlertProps) {
-  return <Alert status="warning" display={{ [sidebarBreakpoint]: "none" }} {...props}>
+  return <Alert status="warning" width="89%" display={{ [sidebarBreakpoint]: "none" }} {...props}>
     <HStack>
       <AlertIcon />
       <AlertDescription>本页内容较多。为了最佳使用体验，建议使用桌面浏览器。</AlertDescription>

--- a/src/components/Navbars.tsx
+++ b/src/components/Navbars.tsx
@@ -115,8 +115,8 @@ const Topbar = ({ onOpen, autosaveState }: TopbarProps) => {
           bg="white"
         />
         <AutosaveIndicator
-          display={{ base: 'block', [sidebarBreakpoint]: 'flex' }}
-          mt={{ base: "50px", [sidebarBreakpoint]: 0 }}
+          display={{ base: 'flex', [sidebarBreakpoint]: 'flex' }}
+          mt={{ base: "80px", [sidebarBreakpoint]: 0 }}
           state={autosaveState}
         />
       </HStack>

--- a/src/components/Navbars.tsx
+++ b/src/components/Navbars.tsx
@@ -115,7 +115,7 @@ const Topbar = ({ onOpen, autosaveState }: TopbarProps) => {
           bg="white"
         />
         <AutosaveIndicator
-          display={{ base: 'flex', [sidebarBreakpoint]: 'flex' }}
+          display="flex"
           mt={{ base: "80px", [sidebarBreakpoint]: 0 }}
           state={autosaveState}
         />

--- a/src/components/Navbars.tsx
+++ b/src/components/Navbars.tsx
@@ -121,7 +121,7 @@ const Topbar = ({ onOpen, autosaveState }: TopbarProps) => {
         />
       </HStack>
 
-      <Box display={{ base: 'flex', [sidebarBreakpoint]: 'none' }}>
+      <Box display="flex">
         <NextLink href="http://yuanjian.org" target="_blank">
         </NextLink>
       </Box>

--- a/src/components/Navbars.tsx
+++ b/src/components/Navbars.tsx
@@ -103,6 +103,7 @@ const Topbar = ({ onOpen, autosaveState }: TopbarProps) => {
       justifyContent="flex-end">
       <HStack spacing={6} marginTop={{ base: 0, [sidebarBreakpoint]: 10 }} >
         <IconButton
+          zIndex={2}
           marginX={4}
           marginTop={4}
           marginBottom={-8}
@@ -114,8 +115,8 @@ const Topbar = ({ onOpen, autosaveState }: TopbarProps) => {
           bg="white"
         />
         <AutosaveIndicator
-          // TODO: Implement on mobile UI
-          display={{ base: 'none', [sidebarBreakpoint]: 'flex' }}
+          display={{ base: 'block', [sidebarBreakpoint]: 'flex' }}
+          mt={{ base: "50px", [sidebarBreakpoint]: 0 }}
           state={autosaveState}
         />
       </HStack>

--- a/src/pages/interviews/[interviewId].tsx
+++ b/src/pages/interviews/[interviewId].tsx
@@ -24,7 +24,7 @@ export default widePage(() => {
   const i = data.interviewWithGroup;
 
   return <Flex direction="column" gap={sectionSpacing}>
-    <MobileExperienceAlert top="-12px" />
+    <MobileExperienceAlert />
 
     <Heading size="md">候选人：{formatUserName(i.interviewee.name)}</Heading>
 

--- a/src/pages/interviews/[interviewId].tsx
+++ b/src/pages/interviews/[interviewId].tsx
@@ -24,7 +24,7 @@ export default widePage(() => {
   const i = data.interviewWithGroup;
 
   return <Flex direction="column" gap={sectionSpacing}>
-    <MobileExperienceAlert />
+    <MobileExperienceAlert top="-12px" />
 
     <Heading size="md">候选人：{formatUserName(i.interviewee.name)}</Heading>
 
@@ -34,26 +34,26 @@ export default widePage(() => {
       </Link>
     </Box>
 
-    <Grid 
-      templateColumns={{ base: "100%", [sidebarBreakpoint]: `repeat(${i.feedbacks.length + 1}, 1fr)` }} 
+    <Grid
+      templateColumns={{ base: "100%", [sidebarBreakpoint]: `repeat(${i.feedbacks.length + 1}, 1fr)` }}
       gap={sectionSpacing}
     >
       {i.feedbacks
         // Fix dislay order
         .sort((f1, f2) => compareUUID(f1.id, f2.id))
         .map(f => <GridItem key={f.id}>
-        <Flex direction="column" gap={sectionSpacing}>
-          <Heading size="md">{formatUserName(f.interviewer.name)}</Heading>
-          <InterviewFeedbackEditor interviewFeedbackId={f.id} readonly={me.id !== f.interviewer.id} />
-        </Flex>
-      </GridItem>)}
+          <Flex direction="column" gap={sectionSpacing}>
+            <Heading size="md">{formatUserName(f.interviewer.name)}</Heading>
+            <InterviewFeedbackEditor interviewFeedbackId={f.id} readonly={me.id !== f.interviewer.id} />
+          </Flex>
+        </GridItem>)}
 
       <GridItem>
         <Flex direction="column" gap={sectionSpacing}>
           <DecisionEditor interviewId={i.id} decision={i.decision} etag={data.etag} />
           {i.type == "MenteeInterview" ?
             <MenteeApplicant userId={i.interviewee.id} showTitle />
-            : 
+            :
             <Text>（导师申请材料页尚未实现）</Text>
           }
         </Flex>


### PR DESCRIPTION
In the old UI, the auto-save indicator is at the top-right without margin. 
After the change, the indicator is at the top-right with margin:
<img width="379" alt="Screenshot 2024-08-13 at 17 41 20" src="https://github.com/user-attachments/assets/ca0b5f3c-574d-4159-852c-90e6596d30f7">
<img width="441" alt="Screenshot 2024-08-13 at 17 41 15" src="https://github.com/user-attachments/assets/d7c796b1-3b8f-4f6f-8442-c4b3a196c4e1">

Adjust the thickness of outline, no much difference since the background is largely white:
<img width="208" alt="Screenshot 2024-08-13 at 22 07 25" src="https://github.com/user-attachments/assets/c05c34a0-87ce-4fcf-be00-6ae2fac7bb44">
<img width="176" alt="Screenshot 2024-08-13 at 22 07 28" src="https://github.com/user-attachments/assets/d36731c5-d9f4-4f42-b352-859a8a235d25">






