### PR TITLE
Sort table based on year

### DIFF
--- a/src/pages/coachees.tsx
+++ b/src/pages/coachees.tsx
@@ -14,7 +14,7 @@ import { trpcNext } from "../trpc";
 import Loader from 'components/Loader';
 import { sectionSpacing } from 'theme/metrics';
 import { ExternalLinkIcon } from '@chakra-ui/icons';
-import { MenteeCells, MentorshipCells, MostRecentChatMessageCell } from './mentees';
+import { MenteeCellsSelfQuery, MentorshipCells, MostRecentChatMessageCell } from './mentees';
 
 export default function Page() {
   const { data: mentorships } = trpcNext.mentorships.listMineAsCoach.useQuery();
@@ -35,11 +35,11 @@ export default function Page() {
       </Thead>
       <Tbody>
         {mentorships.map(m => <Tr key={m.id} _hover={{ bg: "white" }}>
-          <MenteeCells mentee={m.mentee} />
+          <MenteeCellsSelfQuery mentee={m.mentee} />
           <MentorshipCells menteeId={m.mentee.id} readonly />
           <MostRecentChatMessageCell menteeId={m.mentee.id} />
         </Tr>
-      )}
+        )}
       </Tbody>
     </Table></TableContainer>}
 

--- a/src/pages/mentees.tsx
+++ b/src/pages/mentees.tsx
@@ -172,6 +172,23 @@ export function MenteeCells({ mentee, year }: {
   </>;
 }
 
+export function MenteeCellsSelfQuery({ mentee }: {
+  mentee: MinUser,
+}) {
+  const { data } = trpcNext.users.getApplicant.useQuery({
+    type: "MenteeInterview",
+    userId: mentee.id,
+  });
+  const year = (data?.application as Record<string, any>)?.[menteeAcceptanceYearField];
+
+  return <>
+    <Td>{year && year}</Td>
+    <Td><Link as={NextLink} href={`/mentees/${mentee.id}`}>
+      {mentee.name} <ChevronRightIcon />
+    </Link></Td>
+  </>;
+}
+
 export function MentorshipCells({ menteeId, addPinyin, showCoach, readonly }: {
   menteeId: string,
   addPinyin?: (names: string[]) => void,


### PR DESCRIPTION
Fixed #327. Instead of querying each user's year information in [menteeCell](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fL139), now [menteeTable](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR76) fetches all users' applications and then passes the [year](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR86) information to [menteeRow](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR124), then [menteeCell](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR163).
Since [menteeCell](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-ba54d1c2595e8049e8f9d2994a2c2b7aa4619ad5f087cb449e7074ab2defc0c0L38) is also imported into [coachees.tsx](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-ba54d1c2595e8049e8f9d2994a2c2b7aa4619ad5f087cb449e7074ab2defc0c0L38) where the year information is not provided, I have created another component named [menteeCellSelfQuery](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR175) that does not require year information to be passed (same as the old [menteeCell](https://github.com/yuanjian-org/app/compare/sort_table_ada?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fL139)).
