### PR TITLE
Sort user using call back function

### DIFF
--- a/src/pages/mentees.tsx
+++ b/src/pages/mentees.tsx
@@ -118,7 +118,8 @@ function MenteeTable({ users, refetch }: {
 
         return idB - idA;
       }).map((u: any) =>
-        <MenteeRow key={u.id} user={u} refetch={refetch} updateMenteeYear={(id: string, year: string) => updateMenteeYear(id, year)} />)
+        <MenteeRow key={u.id} user={u} refetch={refetch} 
+          updateMenteeYear={(id: string, year: string) => updateMenteeYear(id, year)} />)
       }
     </Tbody>
   </Table>;

--- a/src/pages/mentees.tsx
+++ b/src/pages/mentees.tsx
@@ -80,7 +80,7 @@ function MenteeTable({ users, refetch }: {
 }) {
   const [menteeToYear, setMenteeToYear] = useState(new Map<string, string>()); 
   const updateMenteeYear = (userId: string, acceptanceYear: string) => {
-    setMenteeToYear((current) => {
+    setMenteeToYear(current => {
       const newMap = new Map(current);
       newMap.set(userId, acceptanceYear);
       return newMap;
@@ -106,7 +106,9 @@ function MenteeTable({ users, refetch }: {
         const yearB = menteeToYear.get(b.id) || "";
 
         if (yearA === yearB) {
-          return (a.name || '').localeCompare(b.name || '');
+          const nameA = formatUserName(a.name, 'formal') || '';
+          const nameB = formatUserName(b.name, 'formal') || '';
+          return nameA.localeCompare(nameB);
         }
 
         return yearB.localeCompare(yearA);

--- a/src/pages/mentees.tsx
+++ b/src/pages/mentees.tsx
@@ -47,7 +47,7 @@ import { formatMentorshipEndedAtText } from './mentees/[userId]';
 import { menteeAcceptanceYearField } from 'shared/menteeApplicationFields';
 
 const fixedFilter: UserFilter = { containsRoles: ["Mentee"] };
-type UpdateMenteeYear = (userId: string, acceptanceYear: string) => void
+type UpdateMenteeYear = (userId: string, acceptanceYear: string) => void;
 
 export default function Page() {
   const [filter, setFilter] = useState<UserFilter>(fixedFilter);
@@ -106,8 +106,8 @@ function MenteeTable({ users, refetch }: {
         const yearB = menteeToYear.get(b.id) || "";
 
         if (yearA === yearB) {
-          const nameA = formatUserName(a.name, 'formal') || '';
-          const nameB = formatUserName(b.name, 'formal') || '';
+          const nameA = formatUserName(a.name, 'formal');
+          const nameB = formatUserName(b.name, 'formal');
           return nameA.localeCompare(nameB);
         }
 
@@ -166,13 +166,16 @@ export function MenteeCells({ mentee, updateMenteeYear } : {
     type: "MenteeInterview",
     userId: mentee.id,
   });
-  const year = (data?.application as Record<string, any>)?.[menteeAcceptanceYearField];
+  
+  const getYear = () => (data?.application as Record<string, any>)?.[menteeAcceptanceYearField];
+  const year = getYear();
+  
   useEffect(() => {
     if (updateMenteeYear) {
-      updateMenteeYear(mentee.id, year);
+      updateMenteeYear(mentee.id, getYear());
     }
   }, [data]);  
-
+  
   return <>
     <Td>{year && year}</Td>
     <Td><Link as={NextLink} href={`/mentees/${mentee.id}`}>


### PR DESCRIPTION
Fixed https://github.com/yuanjian-org/app/issues/327.

1. Re-rendering Issue: Each time the menteeCell component re-renders, it triggers a tRPC query which can be found here: [trpc query](https://github.com/yuanjian-org/app/compare/sort_table_function?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR170).

2. State Management: Additional React lifecycle hooks are being maintained: useState and useEffect, which are located here: [useState](https://github.com/yuanjian-org/app/compare/sort_table_function?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR81) and [useEffect](https://github.com/yuanjian-org/app/compare/sort_table_function?expand=1#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR175).

3. Efficiency of Queries: The [tRPC useQueries](https://github.com/yuanjian-org/app/pull/332/files#diff-065d898ce719572a882d2db4ba49094c4557609c70696bdd082c874845e3056fR80) runs in parallel and only queries the users that are passed to it, not all users. Centralizing all data within the menteeTable could facilitate better data management and potentially improve efficiency.