### PR TITLE
Remove primary key tags from map model

### DIFF
--- a/src/api/database/models/map/LandmarkScoreLog.ts
+++ b/src/api/database/models/map/LandmarkScoreLog.ts
@@ -2,7 +2,6 @@ import {
   Column,
   Table,
   Model,
-  PrimaryKey,
   ForeignKey,
 } from "sequelize-typescript";
 import { UUID, STRING, INTEGER } from "sequelize";

--- a/src/api/database/models/map/LandmarkScoreLog.ts
+++ b/src/api/database/models/map/LandmarkScoreLog.ts
@@ -20,12 +20,10 @@ import { zLandmarkScore, LandmarkScore } from "../../../../shared/Map";
   ],
 })
 class LandmarkScoreLog extends Model {
-  @PrimaryKey
   @ForeignKey(() => User)
   @Column(UUID)
   userId: string;
 
-  @PrimaryKey
   @Column(STRING)
   landmark: string;
 


### PR DESCRIPTION
Remove `@ primary key` from `userId` and `landmark` fields of the Map model