### PR TITLE
Add AssessorId to LandmarkAssessment Table

### DIFF
--- a/src/api/database/models/User.ts
+++ b/src/api/database/models/User.ts
@@ -122,9 +122,6 @@ class User extends Model {
   @BelongsTo(() => User, { foreignKey: 'pointOfContactId' })
   pointOfContact: User | null;
 
-  @HasMany(() => LandmarkAssessment)
-  landmarkAssessments: LandmarkAssessment[];
-
   @BeforeDestroy
   static async cascadeDelete(user: User, options: any) {
 

--- a/src/api/database/models/User.ts
+++ b/src/api/database/models/User.ts
@@ -26,7 +26,6 @@ import Interview from "./Interview";
 import GroupUser from "./GroupUser";
 import Mentorship from "./Mentorship";
 import { MenteeStatus, zMenteeStatus } from "../../../shared/MenteeStatus";
-import LandmarkAssessment from "./map/LandmarkAssessment";
 
 
 @Table({ paranoid: true, tableName: "users", modelName: "user" })

--- a/src/api/database/models/User.ts
+++ b/src/api/database/models/User.ts
@@ -26,6 +26,7 @@ import Interview from "./Interview";
 import GroupUser from "./GroupUser";
 import Mentorship from "./Mentorship";
 import { MenteeStatus, zMenteeStatus } from "../../../shared/MenteeStatus";
+import LandmarkAssessment from "./map/LandmarkAssessment";
 
 
 @Table({ paranoid: true, tableName: "users", modelName: "user" })
@@ -120,6 +121,9 @@ class User extends Model {
 
   @BelongsTo(() => User, { foreignKey: 'pointOfContactId' })
   pointOfContact: User | null;
+
+  @HasMany(() => LandmarkAssessment)
+  landmarkAssessments: LandmarkAssessment[];
 
   @BeforeDestroy
   static async cascadeDelete(user: User, options: any) {

--- a/src/api/database/models/map/LandmarkAssessment.ts
+++ b/src/api/database/models/map/LandmarkAssessment.ts
@@ -3,6 +3,7 @@ import {
   Table,
   Model,
   ForeignKey,
+  HasOne,
 } from "sequelize-typescript";
 import { UUID, STRING, INTEGER } from "sequelize";
 import User from "../User";
@@ -26,6 +27,9 @@ class LandmarkAssessment extends Model {
   @ForeignKey(() => User)
   @Column(UUID)
   assessorId: string | null;
+
+  @HasOne(() => User)
+  assessor: User | null;
 
   @Column(STRING)
   landmark: string;

--- a/src/api/database/models/map/LandmarkAssessment.ts
+++ b/src/api/database/models/map/LandmarkAssessment.ts
@@ -24,7 +24,7 @@ class LandmarkAssessment extends Model {
   @Column(UUID)
   userId: string;
 
-  // If assessorId (assessor) is null, the landmark assessment is self-evaluated by the user; 
+  // If assessorId (assessor) is null, the landmark assessment is self-evaluated
   // otherwise, it is evaluated by others.
   @ForeignKey(() => User)
   @Column(UUID)

--- a/src/api/database/models/map/LandmarkAssessment.ts
+++ b/src/api/database/models/map/LandmarkAssessment.ts
@@ -23,6 +23,10 @@ class LandmarkAssessment extends Model {
   @Column(UUID)
   userId: string;
 
+  @ForeignKey(() => User)
+  @Column(UUID)
+  assessorId: string | null;
+
   @Column(STRING)
   landmark: string;
 

--- a/src/api/database/models/map/LandmarkAssessment.ts
+++ b/src/api/database/models/map/LandmarkAssessment.ts
@@ -3,7 +3,7 @@ import {
   Table,
   Model,
   ForeignKey,
-  HasOne,
+  BelongsTo,
 } from "sequelize-typescript";
 import { UUID, STRING, INTEGER } from "sequelize";
 import User from "../User";
@@ -28,7 +28,7 @@ class LandmarkAssessment extends Model {
   @Column(UUID)
   assessorId: string | null;
 
-  @HasOne(() => User)
+  @BelongsTo(() => User, { foreignKey: 'assessorId' })
   assessor: User | null;
 
   @Column(STRING)

--- a/src/api/database/models/map/LandmarkAssessment.ts
+++ b/src/api/database/models/map/LandmarkAssessment.ts
@@ -24,6 +24,8 @@ class LandmarkAssessment extends Model {
   @Column(UUID)
   userId: string;
 
+  // If assessorId (assessor) is null, the landmark assessment is self-evaluated by the user; 
+  // otherwise, it is evaluated by others.
   @ForeignKey(() => User)
   @Column(UUID)
   assessorId: string | null;


### PR DESCRIPTION
Add `assessorId` in `LandmarkAssessment`to allow permitted users to access specific Landmark assessment histories.