### PR TITLE
Potential fix for code scanning alert no. 18: Exception text reinterpreted as HTML

### DIFF
--- a/src/pages/api/oauth2/logout.test.ts
+++ b/src/pages/api/oauth2/logout.test.ts
@@ -40,7 +40,7 @@ describe("OAuth2 /api/oauth2/logout API Endpoint", function () {
       );
     } catch (err: any) {
       res.statusCode = 500;
-      res.end(err.message);
+      res.end("Internal Server Error");
     }
   };
 

--- a/src/pages/api/oauth2/logout.test.ts
+++ b/src/pages/api/oauth2/logout.test.ts
@@ -1,9 +1,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { createServer } from "http";
 import request from "supertest";
-import { apiResolver } from "next/dist/server/api-utils/node/api-resolver";
-import url from "url";
+import { createTestServer } from "../../../api/oauth2/testUtils";
 import handler from "./logout";
 
 describe("OAuth2 /api/oauth2/logout API Endpoint", function () {
@@ -21,30 +19,7 @@ describe("OAuth2 /api/oauth2/logout API Endpoint", function () {
     sinon.restore();
   });
 
-  const requestListener = async (req: any, res: any) => {
-    try {
-      // supertest does not automatically parse the query string, but apiResolver requires it
-      req.query = url.parse(req.url, true).query;
-
-      await apiResolver(
-        req,
-        res,
-        req.query,
-        handler,
-        {
-          previewModeEncryptionKey: "",
-          previewModeId: "",
-          previewModeSigningKey: "",
-        },
-        true,
-      );
-    } catch (err: any) {
-      res.statusCode = 500;
-      res.end("Internal Server Error");
-    }
-  };
-
-  const app = createServer(requestListener);
+  const app = createTestServer(handler);
 
   it("should return 405 for methods other than GET or POST", async () => {
     const res = await request(app).put("/");


### PR DESCRIPTION
Potential fix for [https://github.com/yuanjian-org/app/security/code-scanning/18](https://github.com/yuanjian-org/app/security/code-scanning/18)

Best fix: do not return raw exception messages to the HTTP response. Instead, return a generic constant error string (optionally log details internally, but not required here). This preserves test behavior for status handling while removing XSS risk from error text reflection.

In `src/pages/api/oauth2/logout.test.ts`, update the `catch` block in `requestListener`:
- Keep `res.statusCode = 500;`
- Replace `res.end(err.message);` with a fixed safe message such as `res.end("Internal Server Error");`

No additional imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
