### PR TITLE
Fix Cypress URL bug and Chinese char display

### DIFF
--- a/.github/workflows/prober.yml
+++ b/.github/workflows/prober.yml
@@ -27,16 +27,15 @@ jobs:
           node-version: '24'
           cache: 'yarn'
 
+      - name: Install Chinese fonts
+        run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
+
       - name: Run Cypress prober
         uses: cypress-io/github-action@v6
         with:
           browser: chrome
           spec: cypress/e2e/prober.test.ts
-          config: >-
-            baseUrl=https://demo.yuantuapp.com,
-            defaultCommandTimeout=15000,
-            pageLoadTimeout=30000,
-            video=true
+          config: baseUrl=https://demo.yuantuapp.com,defaultCommandTimeout=15000,pageLoadTimeout=30000,video=true
 
       - name: Upload failure artifacts
         if: failure()

--- a/cypress/e2e/prober.test.ts
+++ b/cypress/e2e/prober.test.ts
@@ -28,7 +28,7 @@ describe("Demo site health check", () => {
   it(
     "can load student profiles (学生档案)",
     () => {
-      cy.visit("/mentees?menteeStatus=现届学子");
+      cy.visit(`/mentees?menteeStatus=${encodeURIComponent("现届学子")}`);
       cy.contains("学生档案", { timeout: 15000 })
         .should("be.visible");
       // The table should list at least one student.
@@ -38,7 +38,7 @@ describe("Demo site health check", () => {
 
   it("can load user management (用户)", () => {
     cy.visit("/users");
-    cy.contains("用户", { timeout: 15000 })
+    cy.contains("新建用户", { timeout: 15000 })
       .should("be.visible");
   });
 });


### PR DESCRIPTION
1. Encode Chinese URL params to fix ERR_UNESCAPED_CHARACTERS in Node 20+

2. Use more specific '新建用户' text instead of generic '用户' to verify users page load

3. Install fonts-noto-cjk in runner so screenshots display Chinese

4. Fix spaces in string array for cypress action config